### PR TITLE
[codex] Add injectable GETC2 and GESC2 symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ All 1315 LAPACK functions from lapack-sys are supported, including:
 - Eigenvalue problems (GEEV, SYEV, HEEV, GEES, etc.)
 - And many more...
 
+Additional Netlib LAPACK auxiliary routines not exposed by lapack-sys are also
+available, including the complete-pivoting LU pair `xGETC2` and `xGESC2`.
+
 ## Features
 
 - `ilp64`: Use 64-bit integers for LAPACK indices (ILP64 ABI)

--- a/scripts/check_symbols.py
+++ b/scripts/check_symbols.py
@@ -7,6 +7,17 @@ import subprocess
 import sys
 from pathlib import Path
 
+SUPPLEMENTAL_SYMBOLS = {
+    "sgetc2_",
+    "dgetc2_",
+    "cgetc2_",
+    "zgetc2_",
+    "sgesc2_",
+    "dgesc2_",
+    "cgesc2_",
+    "zgesc2_",
+}
+
 def get_expected_symbols(lapack_sys_path: Path) -> set:
     """Extract expected symbol names from lapack-sys."""
     import re
@@ -15,6 +26,7 @@ def get_expected_symbols(lapack_sys_path: Path) -> set:
     symbols = set()
     for match in re.finditer(pattern, content):
         symbols.add(match.group(1))
+    symbols.update(SUPPLEMENTAL_SYMBOLS)
     return symbols
 
 def get_exported_symbols(dylib_path: Path) -> set:

--- a/scripts/generate_lapack_bindings.py
+++ b/scripts/generate_lapack_bindings.py
@@ -19,6 +19,77 @@ class Function:
     name: str  # e.g., "dgesv_"
     params: List[Param]
 
+SUPPLEMENTAL_FUNCTIONS = [
+    Function("cgesc2_", [
+        Param("n", "*const c_int"),
+        Param("A", "*const __BindgenComplex<f32>"),
+        Param("lda", "*const c_int"),
+        Param("rhs", "*mut __BindgenComplex<f32>"),
+        Param("ipiv", "*const c_int"),
+        Param("jpiv", "*const c_int"),
+        Param("scale", "*mut f32"),
+    ]),
+    Function("dgesc2_", [
+        Param("n", "*const c_int"),
+        Param("A", "*const f64"),
+        Param("lda", "*const c_int"),
+        Param("rhs", "*mut f64"),
+        Param("ipiv", "*const c_int"),
+        Param("jpiv", "*const c_int"),
+        Param("scale", "*mut f64"),
+    ]),
+    Function("sgesc2_", [
+        Param("n", "*const c_int"),
+        Param("A", "*const f32"),
+        Param("lda", "*const c_int"),
+        Param("rhs", "*mut f32"),
+        Param("ipiv", "*const c_int"),
+        Param("jpiv", "*const c_int"),
+        Param("scale", "*mut f32"),
+    ]),
+    Function("zgesc2_", [
+        Param("n", "*const c_int"),
+        Param("A", "*const __BindgenComplex<f64>"),
+        Param("lda", "*const c_int"),
+        Param("rhs", "*mut __BindgenComplex<f64>"),
+        Param("ipiv", "*const c_int"),
+        Param("jpiv", "*const c_int"),
+        Param("scale", "*mut f64"),
+    ]),
+    Function("cgetc2_", [
+        Param("n", "*const c_int"),
+        Param("A", "*mut __BindgenComplex<f32>"),
+        Param("lda", "*const c_int"),
+        Param("ipiv", "*mut c_int"),
+        Param("jpiv", "*mut c_int"),
+        Param("info", "*mut c_int"),
+    ]),
+    Function("dgetc2_", [
+        Param("n", "*const c_int"),
+        Param("A", "*mut f64"),
+        Param("lda", "*const c_int"),
+        Param("ipiv", "*mut c_int"),
+        Param("jpiv", "*mut c_int"),
+        Param("info", "*mut c_int"),
+    ]),
+    Function("sgetc2_", [
+        Param("n", "*const c_int"),
+        Param("A", "*mut f32"),
+        Param("lda", "*const c_int"),
+        Param("ipiv", "*mut c_int"),
+        Param("jpiv", "*mut c_int"),
+        Param("info", "*mut c_int"),
+    ]),
+    Function("zgetc2_", [
+        Param("n", "*const c_int"),
+        Param("A", "*mut __BindgenComplex<f64>"),
+        Param("lda", "*const c_int"),
+        Param("ipiv", "*mut c_int"),
+        Param("jpiv", "*mut c_int"),
+        Param("info", "*mut c_int"),
+    ]),
+]
+
 def parse_lapack_rs(path: Path) -> List[Function]:
     """Parse lapack.rs and extract function signatures."""
     content = path.read_text()
@@ -172,6 +243,8 @@ def main():
 
     # Filter out lsame_ and other utility functions we handle separately
     functions = [f for f in functions if f.name not in ['lsame_']]
+    existing_names = {f.name for f in functions}
+    functions.extend(f for f in SUPPLEMENTAL_FUNCTIONS if f.name not in existing_names)
 
     # Categorize
     categories = categorize_functions(functions)
@@ -186,7 +259,7 @@ def main():
         '//! function pointers at runtime. Each function has its own `OnceLock` to allow',
         '//! partial registration (only register the functions you need).',
         '//!',
-        '//! Auto-generated from lapack-sys.',
+        '//! Auto-generated from lapack-sys plus supplemental Netlib LAPACK routines.',
         '',
         '#![allow(non_camel_case_types)]',
         '#![allow(non_snake_case)]',
@@ -269,7 +342,7 @@ def main():
         '//! the registered function pointers. This allows lapack-inject to be a drop-in',
         '//! replacement for lapack-src.',
         '//!',
-        '//! Auto-generated from lapack-sys.',
+        '//! Auto-generated from lapack-sys plus supplemental Netlib LAPACK routines.',
         '',
         '#![allow(non_snake_case)]',
         '#![allow(clippy::too_many_arguments)]',

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -4,7 +4,7 @@
 //! function pointers at runtime. Each function has its own `OnceLock` to allow
 //! partial registration (only register the functions you need).
 //!
-//! Auto-generated from lapack-sys.
+//! Auto-generated from lapack-sys plus supplemental Netlib LAPACK routines.
 
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
@@ -3439,6 +3439,47 @@ define_lapack_ffi!(zgerqf, ZgerqfFnPtr,
     info: *mut lapackint,
 );
 
+// GESC2
+define_lapack_ffi!(cgesc2, Cgesc2FnPtr,
+    n: *const lapackint,
+    A: *const Complex32,
+    lda: *const lapackint,
+    rhs: *mut Complex32,
+    ipiv: *const lapackint,
+    jpiv: *const lapackint,
+    scale: *mut f32,
+);
+
+define_lapack_ffi!(dgesc2, Dgesc2FnPtr,
+    n: *const lapackint,
+    A: *const f64,
+    lda: *const lapackint,
+    rhs: *mut f64,
+    ipiv: *const lapackint,
+    jpiv: *const lapackint,
+    scale: *mut f64,
+);
+
+define_lapack_ffi!(sgesc2, Sgesc2FnPtr,
+    n: *const lapackint,
+    A: *const f32,
+    lda: *const lapackint,
+    rhs: *mut f32,
+    ipiv: *const lapackint,
+    jpiv: *const lapackint,
+    scale: *mut f32,
+);
+
+define_lapack_ffi!(zgesc2, Zgesc2FnPtr,
+    n: *const lapackint,
+    A: *const Complex64,
+    lda: *const lapackint,
+    rhs: *mut Complex64,
+    ipiv: *const lapackint,
+    jpiv: *const lapackint,
+    scale: *mut f64,
+);
+
 // GESDD
 define_lapack_ffi!(cgesdd, CgesddFnPtr,
     jobz: *const c_char,
@@ -4118,6 +4159,43 @@ define_lapack_ffi!(zgesvxx, ZgesvxxFnPtr,
     params: *mut f64,
     work: *mut Complex64,
     rwork: *mut f64,
+    info: *mut lapackint,
+);
+
+// GETC2
+define_lapack_ffi!(cgetc2, Cgetc2FnPtr,
+    n: *const lapackint,
+    A: *mut Complex32,
+    lda: *const lapackint,
+    ipiv: *mut lapackint,
+    jpiv: *mut lapackint,
+    info: *mut lapackint,
+);
+
+define_lapack_ffi!(dgetc2, Dgetc2FnPtr,
+    n: *const lapackint,
+    A: *mut f64,
+    lda: *const lapackint,
+    ipiv: *mut lapackint,
+    jpiv: *mut lapackint,
+    info: *mut lapackint,
+);
+
+define_lapack_ffi!(sgetc2, Sgetc2FnPtr,
+    n: *const lapackint,
+    A: *mut f32,
+    lda: *const lapackint,
+    ipiv: *mut lapackint,
+    jpiv: *mut lapackint,
+    info: *mut lapackint,
+);
+
+define_lapack_ffi!(zgetc2, Zgetc2FnPtr,
+    n: *const lapackint,
+    A: *mut Complex64,
+    lda: *const lapackint,
+    ipiv: *mut lapackint,
+    jpiv: *mut lapackint,
     info: *mut lapackint,
 );
 

--- a/src/fortran.rs
+++ b/src/fortran.rs
@@ -4,7 +4,7 @@
 //! the registered function pointers. This allows lapack-inject to be a drop-in
 //! replacement for lapack-src.
 //!
-//! Auto-generated from lapack-sys.
+//! Auto-generated from lapack-sys plus supplemental Netlib LAPACK routines.
 
 #![allow(non_snake_case)]
 #![allow(clippy::too_many_arguments)]
@@ -3401,6 +3401,47 @@ export_fortran_symbol!(zgerqf,
     info: *mut lapackint,
 );
 
+// GESC2
+export_fortran_symbol!(cgesc2,
+    n: *const lapackint,
+    A: *const Complex32,
+    lda: *const lapackint,
+    rhs: *mut Complex32,
+    ipiv: *const lapackint,
+    jpiv: *const lapackint,
+    scale: *mut f32,
+);
+
+export_fortran_symbol!(dgesc2,
+    n: *const lapackint,
+    A: *const f64,
+    lda: *const lapackint,
+    rhs: *mut f64,
+    ipiv: *const lapackint,
+    jpiv: *const lapackint,
+    scale: *mut f64,
+);
+
+export_fortran_symbol!(sgesc2,
+    n: *const lapackint,
+    A: *const f32,
+    lda: *const lapackint,
+    rhs: *mut f32,
+    ipiv: *const lapackint,
+    jpiv: *const lapackint,
+    scale: *mut f32,
+);
+
+export_fortran_symbol!(zgesc2,
+    n: *const lapackint,
+    A: *const Complex64,
+    lda: *const lapackint,
+    rhs: *mut Complex64,
+    ipiv: *const lapackint,
+    jpiv: *const lapackint,
+    scale: *mut f64,
+);
+
 // GESDD
 export_fortran_symbol!(cgesdd,
     jobz: *const c_char,
@@ -4080,6 +4121,43 @@ export_fortran_symbol!(zgesvxx,
     params: *mut f64,
     work: *mut Complex64,
     rwork: *mut f64,
+    info: *mut lapackint,
+);
+
+// GETC2
+export_fortran_symbol!(cgetc2,
+    n: *const lapackint,
+    A: *mut Complex32,
+    lda: *const lapackint,
+    ipiv: *mut lapackint,
+    jpiv: *mut lapackint,
+    info: *mut lapackint,
+);
+
+export_fortran_symbol!(dgetc2,
+    n: *const lapackint,
+    A: *mut f64,
+    lda: *const lapackint,
+    ipiv: *mut lapackint,
+    jpiv: *mut lapackint,
+    info: *mut lapackint,
+);
+
+export_fortran_symbol!(sgetc2,
+    n: *const lapackint,
+    A: *mut f32,
+    lda: *const lapackint,
+    ipiv: *mut lapackint,
+    jpiv: *mut lapackint,
+    info: *mut lapackint,
+);
+
+export_fortran_symbol!(zgetc2,
+    n: *const lapackint,
+    A: *mut Complex64,
+    lda: *const lapackint,
+    ipiv: *mut lapackint,
+    jpiv: *mut lapackint,
     info: *mut lapackint,
 );
 

--- a/tests/getc2_gesc2_symbols.rs
+++ b/tests/getc2_gesc2_symbols.rs
@@ -1,0 +1,188 @@
+//! Tests for supplemental Netlib LAPACK complete-pivoting LU symbols.
+//!
+//! lapack-sys does not declare xGETC2/xGESC2, so these tests declare the
+//! Fortran symbols directly and verify lapack-inject's registration dispatch.
+
+extern crate lapack_inject;
+
+use lapack_inject::*;
+use num_complex::{Complex32, Complex64};
+use std::sync::atomic::{AtomicI32, Ordering};
+
+extern "C" {
+    fn sgetc2_(
+        n: *const lapackint,
+        a: *mut f32,
+        lda: *const lapackint,
+        ipiv: *mut lapackint,
+        jpiv: *mut lapackint,
+        info: *mut lapackint,
+    );
+    fn dgetc2_(
+        n: *const lapackint,
+        a: *mut f64,
+        lda: *const lapackint,
+        ipiv: *mut lapackint,
+        jpiv: *mut lapackint,
+        info: *mut lapackint,
+    );
+    fn cgetc2_(
+        n: *const lapackint,
+        a: *mut Complex32,
+        lda: *const lapackint,
+        ipiv: *mut lapackint,
+        jpiv: *mut lapackint,
+        info: *mut lapackint,
+    );
+    fn zgetc2_(
+        n: *const lapackint,
+        a: *mut Complex64,
+        lda: *const lapackint,
+        ipiv: *mut lapackint,
+        jpiv: *mut lapackint,
+        info: *mut lapackint,
+    );
+    fn sgesc2_(
+        n: *const lapackint,
+        a: *const f32,
+        lda: *const lapackint,
+        rhs: *mut f32,
+        ipiv: *const lapackint,
+        jpiv: *const lapackint,
+        scale: *mut f32,
+    );
+    fn dgesc2_(
+        n: *const lapackint,
+        a: *const f64,
+        lda: *const lapackint,
+        rhs: *mut f64,
+        ipiv: *const lapackint,
+        jpiv: *const lapackint,
+        scale: *mut f64,
+    );
+    fn cgesc2_(
+        n: *const lapackint,
+        a: *const Complex32,
+        lda: *const lapackint,
+        rhs: *mut Complex32,
+        ipiv: *const lapackint,
+        jpiv: *const lapackint,
+        scale: *mut f32,
+    );
+    fn zgesc2_(
+        n: *const lapackint,
+        a: *const Complex64,
+        lda: *const lapackint,
+        rhs: *mut Complex64,
+        ipiv: *const lapackint,
+        jpiv: *const lapackint,
+        scale: *mut f64,
+    );
+}
+
+static DGETC2_STATUS: AtomicI32 = AtomicI32::new(0);
+static DGESC2_STATUS: AtomicI32 = AtomicI32::new(0);
+
+unsafe extern "C" fn fake_dgetc2(
+    n: *const lapackint,
+    a: *mut f64,
+    lda: *const lapackint,
+    ipiv: *mut lapackint,
+    jpiv: *mut lapackint,
+    info: *mut lapackint,
+) {
+    if *n != 1 {
+        DGETC2_STATUS.store(1, Ordering::SeqCst);
+    }
+    if *lda != 1 {
+        DGETC2_STATUS.store(2, Ordering::SeqCst);
+    }
+    if (*a - 4.0).abs() > f64::EPSILON {
+        DGETC2_STATUS.store(3, Ordering::SeqCst);
+    }
+
+    *ipiv = 1;
+    *jpiv = 1;
+    *info = 0;
+}
+
+unsafe extern "C" fn fake_dgesc2(
+    n: *const lapackint,
+    a: *const f64,
+    lda: *const lapackint,
+    rhs: *mut f64,
+    ipiv: *const lapackint,
+    jpiv: *const lapackint,
+    scale: *mut f64,
+) {
+    if *n != 1 {
+        DGESC2_STATUS.store(1, Ordering::SeqCst);
+    }
+    if *lda != 1 {
+        DGESC2_STATUS.store(2, Ordering::SeqCst);
+    }
+    if (*ipiv, *jpiv) != (1, 1) {
+        DGESC2_STATUS.store(3, Ordering::SeqCst);
+    }
+
+    *rhs /= *a;
+    *scale = 1.0;
+}
+
+#[test]
+fn getc2_and_gesc2_symbols_have_expected_function_pointer_types() {
+    let _: Sgetc2FnPtr = sgetc2_;
+    let _: Dgetc2FnPtr = dgetc2_;
+    let _: Cgetc2FnPtr = cgetc2_;
+    let _: Zgetc2FnPtr = zgetc2_;
+
+    let _: Sgesc2FnPtr = sgesc2_;
+    let _: Dgesc2FnPtr = dgesc2_;
+    let _: Cgesc2FnPtr = cgesc2_;
+    let _: Zgesc2FnPtr = zgesc2_;
+}
+
+#[test]
+fn dgetc2_and_dgesc2_dispatch_through_registered_function_pointers() {
+    unsafe {
+        register_dgetc2(fake_dgetc2);
+        register_dgesc2(fake_dgesc2);
+    }
+
+    let n: lapackint = 1;
+    let lda: lapackint = 1;
+    let mut a = [4.0_f64];
+    let mut rhs = [8.0_f64];
+    let mut ipiv: [lapackint; 1] = [0];
+    let mut jpiv: [lapackint; 1] = [0];
+    let mut info: lapackint = -1;
+    let mut scale = 0.0_f64;
+
+    unsafe {
+        dgetc2_(
+            &n,
+            a.as_mut_ptr(),
+            &lda,
+            ipiv.as_mut_ptr(),
+            jpiv.as_mut_ptr(),
+            &mut info,
+        );
+        dgesc2_(
+            &n,
+            a.as_ptr(),
+            &lda,
+            rhs.as_mut_ptr(),
+            ipiv.as_ptr(),
+            jpiv.as_ptr(),
+            &mut scale,
+        );
+    }
+
+    assert_eq!(DGETC2_STATUS.load(Ordering::SeqCst), 0);
+    assert_eq!(DGESC2_STATUS.load(Ordering::SeqCst), 0);
+    assert_eq!(info, 0);
+    assert_eq!(ipiv, [1]);
+    assert_eq!(jpiv, [1]);
+    assert_eq!(rhs, [2.0]);
+    assert_eq!(scale, 1.0);
+}


### PR DESCRIPTION
## Summary

- Add injectable `s/d/c/zgetc2` and `s/d/c/zgesc2` function pointer registrations and Fortran ABI exports.
- Add supplemental generator/check-symbol definitions so these Netlib LAPACK routines are preserved outside `lapack-sys` coverage.
- Add direct FFI tests for symbol type compatibility and `dgetc2_` / `dgesc2_` dispatch through registered pointers.

Closes #1

## Validation

- `cargo test`
- `cargo test --test getc2_gesc2_symbols --features ilp64`
- `python3 -m py_compile scripts/generate_lapack_bindings.py scripts/check_symbols.py`
- `cargo fmt -- --check` was run and still reports the repository existing generated-code / `tests/functional_test.rs` formatting diffs; CI marks this check `continue-on-error` for that reason.
