### PR TITLE
[codex] Complete tenferro LAPACK provider surface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lapack-inject"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Hiroshi Shinaoka <shinaoka@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -50,8 +50,12 @@ registered.
 
 The generated Fortran surface supports:
 
-- `xGESV`, `xGETRF`, `xGETRS`, `xGETRI`, `xPOTRF`, and `xGESVD`
-- `sSYEV` and `dSYEV`
+- `xGESV`, `xGETRF`, `xGETRS`, `xGETRI`, `xPOTRF`
+- `xGESVD`
+- `xGEQRF`, real `xORGQR`, complex `xUNGQR`
+- `xTRTRS`
+- `s/dSYEV`, `c/zHEEV`
+- `xGEEV`
 - Supplemental complete-pivoting LU routines `xGETC2` and `xGESC2`
 
 The LAPACKE surface currently covers the double-precision routines listed
@@ -64,6 +68,11 @@ above in the Usage section.
   symbol name for LP64 and ILP64 callers. The LAPACKE C API exposes `_64`
   functions separately, so those C entry points do not require this feature to
   select 64-bit integer arguments.
+
+The default build keeps the consumer-facing Fortran symbols LP64-compatible.
+Register ILP64 host providers with the `_ilp64` registration functions; do not
+enable the `ilp64` feature just because the host provider is ILP64. The feature
+changes the consumer ABI too.
 
 ## License
 

--- a/scripts/check_symbols.py
+++ b/scripts/check_symbols.py
@@ -3,20 +3,11 @@
 Check that all expected LAPACK symbols are exported from the built library.
 """
 
+import argparse
 import subprocess
 import sys
 from pathlib import Path
 
-SUPPLEMENTAL_SYMBOLS = {
-    "sgetc2_",
-    "dgetc2_",
-    "cgetc2_",
-    "zgetc2_",
-    "sgesc2_",
-    "dgesc2_",
-    "cgesc2_",
-    "zgesc2_",
-}
 
 def get_expected_symbols(lapack_sys_path: Path) -> set:
     """Extract expected symbol names from lapack-sys."""
@@ -26,8 +17,8 @@ def get_expected_symbols(lapack_sys_path: Path) -> set:
     symbols = set()
     for match in re.finditer(pattern, content):
         symbols.add(match.group(1))
-    symbols.update(SUPPLEMENTAL_SYMBOLS)
     return symbols
+
 
 def get_exported_symbols(dylib_path: Path) -> set:
     """Get exported symbols from the built library."""
@@ -41,30 +32,58 @@ def get_exported_symbols(dylib_path: Path) -> set:
     for line in result.stdout.split('\n'):
         parts = line.split()
         if len(parts) >= 3 and parts[1] == 'T':
-            # Remove leading underscore (macOS convention)
             name = parts[2].lstrip('_')
             if name.endswith('_'):
                 symbols.add(name)
     return symbols
 
-def main():
-    lapack_sys = Path("/Users/hiroshi/git/lapack-sys/src/lapack.rs")
 
-    # Try both debug and release
-    for profile in ['debug', 'release']:
-        dylib = Path(f"/Users/hiroshi/projects/tensor4all/lapack-inject/target/{profile}/liblapack_inject.dylib")
-        if dylib.exists():
-            break
-    else:
-        print("Error: Library not found. Run 'cargo build' first.")
+def get_generated_set() -> set:
+    """Return the set of LAPACK symbols the generator currently produces."""
+    return {
+        "sgesv_", "dgesv_", "cgesv_", "zgesv_",
+        "sgetrf_", "dgetrf_", "cgetrf_", "zgetrf_",
+        "sgetrs_", "dgetrs_", "cgetrs_", "zgetrs_",
+        "sgetri_", "dgetri_", "cgetri_", "zgetri_",
+        "spotrf_", "dpotrf_", "cpotrf_", "zpotrf_",
+        "ssyev_", "dsyev_",
+        "sgesvd_", "dgesvd_", "cgesvd_", "zgesvd_",
+        "sgeqrf_", "dgeqrf_", "cgeqrf_", "zgeqrf_",
+        "sorgqr_", "dorgqr_",
+        "cungqr_", "zungqr_",
+        "strtrs_", "dtrtrs_", "ctrtrs_", "ztrtrs_",
+        "sgeev_", "dgeev_", "cgeev_", "zgeev_",
+        "cheev_", "zheev_",
+        "sgetc2_", "dgetc2_", "cgetc2_", "zgetc2_",
+        "sgesc2_", "dgesc2_", "cgesc2_", "zgesc2_",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--lapack-sys-path', type=str, required=True,
+                        help='Path to lapack-sys lapack.rs')
+    parser.add_argument('--library', type=str, required=True,
+                        help='Path to the built liblapack_inject library')
+    parser.add_argument('--all', action='store_true',
+                        help='Check against all lapack-sys symbols instead of generated set')
+    args = parser.parse_args()
+
+    lapack_sys = Path(args.lapack_sys_path)
+    dylib = Path(args.library)
+
+    if not dylib.exists():
+        print(f"Error: Library not found: {dylib}")
         sys.exit(1)
 
     print(f"Checking {dylib}...")
 
-    expected = get_expected_symbols(lapack_sys)
-    exported = get_exported_symbols(dylib)
+    if args.all:
+        expected = get_expected_symbols(lapack_sys)
+    else:
+        expected = get_generated_set()
 
-    # Filter to only LAPACK symbols (s/d/c/z prefix)
+    exported = get_exported_symbols(dylib)
     lapack_exported = {s for s in exported if s[0] in 'sdcz' and s.endswith('_')}
 
     print(f"Expected symbols: {len(expected)}")
@@ -86,11 +105,12 @@ def main():
             print(f"  {s}")
 
     if not missing:
-        print("\n✓ All expected symbols are exported!")
+        print("\nAll expected symbols are exported!")
         return 0
     else:
-        print(f"\n✗ {len(missing)} symbols missing")
+        print(f"\n{len(missing)} symbols missing")
         return 1
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/generate_lapack_bindings.py
+++ b/scripts/generate_lapack_bindings.py
@@ -109,6 +109,91 @@ SUPPLEMENTAL_FUNCTIONS = [
     ]),
 ]
 
+# Metadata: which *mut/*const c_int params are integer arrays (not scalars).
+# Maps function name -> {param_name: size_expression}
+# size_expression uses other parameter names from the function signature.
+ARRAY_INT_PARAMS = {
+    "sgesv_": {"ipiv": "n"},
+    "dgesv_": {"ipiv": "n"},
+    "cgesv_": {"ipiv": "n"},
+    "zgesv_": {"ipiv": "n"},
+    "sgetrf_": {"ipiv": "min(m,n)"},
+    "dgetrf_": {"ipiv": "min(m,n)"},
+    "cgetrf_": {"ipiv": "min(m,n)"},
+    "zgetrf_": {"ipiv": "min(m,n)"},
+    "sgetrs_": {"ipiv": "n"},
+    "dgetrs_": {"ipiv": "n"},
+    "cgetrs_": {"ipiv": "n"},
+    "zgetrs_": {"ipiv": "n"},
+    "sgetri_": {"ipiv": "n"},
+    "dgetri_": {"ipiv": "n"},
+    "cgetri_": {"ipiv": "n"},
+    "zgetri_": {"ipiv": "n"},
+    "sgetc2_": {"ipiv": "n", "jpiv": "n"},
+    "dgetc2_": {"ipiv": "n", "jpiv": "n"},
+    "cgetc2_": {"ipiv": "n", "jpiv": "n"},
+    "zgetc2_": {"ipiv": "n", "jpiv": "n"},
+    "sgesc2_": {"ipiv": "n", "jpiv": "n"},
+    "dgesc2_": {"ipiv": "n", "jpiv": "n"},
+    "cgesc2_": {"ipiv": "n", "jpiv": "n"},
+    "zgesc2_": {"ipiv": "n", "jpiv": "n"},
+}
+
+
+def _array_size_expr(size_expr: str, suffix: str) -> str:
+    """Convert a size expression template to a Rust expression.
+
+    'n'         -> 'n_lp64 as usize'
+    'min(m,n)'  -> 'std::cmp::min(m_lp64, n_lp64) as usize'
+    """
+    def repl(m):
+        w = m.group(1)
+        if w == 'min':
+            return 'std::cmp::min'
+        return f'{w}_{suffix}'
+    result = re.sub(r'([a-zA-Z_]\w*)', repl, size_expr)
+    return result + ' as usize'
+
+
+def _array_param_arm(lines, writeback, p, size_expr, suffix, width, is_mut):
+    """Generate bridging code for one array param in one dispatch arm.
+
+    When consumer width matches provider width, pass the original pointer.
+    When widths differ (cross-width), allocate a Vec, copy elements,
+    pass the Vec pointer, and for *mut write back element-by-element.
+
+    suffix: 'lp64' or 'ilp64'
+    width: 'i32' or 'i64' (the provider's expected integer width)
+    """
+    vec_name = f"{p.name}_{suffix}_vec"
+    is_lp64_arm = suffix == 'lp64'
+    # In the LP64 arm, widths match in the default build (not ilp64).
+    # In the ILP64 arm, widths match in the ilp64 build.
+    cfg_match = 'cfg(not(feature = "ilp64"))' if is_lp64_arm else 'cfg(feature = "ilp64")'
+    cfg_cross = 'cfg(feature = "ilp64")' if is_lp64_arm else 'cfg(not(feature = "ilp64"))'
+
+    # Pass original pointer when consumer width matches provider width
+    lines.append(f"            #[{cfg_match}]")
+    lines.append(f"            let {vec_name}_ptr = {p.name};")
+    # Cross-width bridging
+    size_rust = _array_size_expr(size_expr, suffix)
+    lines.append(f"            #[{cfg_cross}]")
+    lines.append(f"            let n_{p.name}_{suffix} = {size_rust};")
+    lines.append(f"            #[{cfg_cross}]")
+    if is_mut:
+        lines.append(f"            let mut {vec_name}: Vec<{width}> = vec![0{width}; n_{p.name}_{suffix}];")
+        lines.append(f"            #[{cfg_cross}]")
+        lines.append(f"            let {vec_name}_ptr = {vec_name}.as_mut_ptr();")
+        writeback.append(f"            #[{cfg_cross}]")
+        writeback.append(f"            for i in 0..n_{p.name}_{suffix} {{ *{p.name}.add(i) = {vec_name}[i] as lapackint; }}")
+    else:
+        lines.append(f"            let {vec_name}: Vec<{width}> = (0..n_{p.name}_{suffix}).map(|i| *{p.name}.add(i) as {width}).collect();")
+        lines.append(f"            #[{cfg_cross}]")
+        lines.append(f"            let {vec_name}_ptr = {vec_name}.as_ptr();")
+
+    return f"{vec_name}_ptr"
+
+
 def parse_lapack_rs(path: Path) -> List[Function]:
     """Parse lapack.rs and extract function signatures."""
     content = path.read_text()
@@ -235,6 +320,7 @@ def generate_fortran_export(func: Function) -> str:
     name = func.name.rstrip('_')
     prefix = get_type_name_prefix(func.name)
     provider_name = f"{prefix}Provider"
+    array_params = ARRAY_INT_PARAMS.get(func.name, {})
 
     params = []
     for p in func.params:
@@ -248,7 +334,18 @@ def generate_fortran_export(func: Function) -> str:
     lp64_writeback = []
     ilp64_writeback = []
     for p in func.params:
-        if p.type_.startswith('*const c_int'):
+        is_array = p.name in array_params
+        if p.type_.startswith('*const c_int') and is_array:
+            param_lp64 = _array_param_arm(lp64_lines, lp64_writeback, p, array_params[p.name], 'lp64', 'i32', is_mut=False)
+            param_ilp64 = _array_param_arm(ilp64_lines, ilp64_writeback, p, array_params[p.name], 'ilp64', 'i64', is_mut=False)
+            lp64_params.append(param_lp64)
+            ilp64_params.append(param_ilp64)
+        elif p.type_.startswith('*mut c_int') and is_array:
+            param_lp64 = _array_param_arm(lp64_lines, lp64_writeback, p, array_params[p.name], 'lp64', 'i32', is_mut=True)
+            param_ilp64 = _array_param_arm(ilp64_lines, ilp64_writeback, p, array_params[p.name], 'ilp64', 'i64', is_mut=True)
+            lp64_params.append(param_lp64)
+            ilp64_params.append(param_ilp64)
+        elif p.type_.startswith('*const c_int'):
             lp64_name = f"{p.name}_lp64"
             ilp64_name = f"{p.name}_ilp64"
             lp64_lines.append(f"            let {lp64_name}: i32 = *{p.name} as i32;")

--- a/scripts/generate_lapack_bindings.py
+++ b/scripts/generate_lapack_bindings.py
@@ -28,6 +28,12 @@ CORE_FUNCTIONS = {
     "spotrf_", "dpotrf_", "cpotrf_", "zpotrf_",
     "ssyev_", "dsyev_",
     "sgesvd_", "dgesvd_", "cgesvd_", "zgesvd_",
+    "sgeqrf_", "dgeqrf_", "cgeqrf_", "zgeqrf_",
+    "sorgqr_", "dorgqr_",
+    "cungqr_", "zungqr_",
+    "strtrs_", "dtrtrs_", "ctrtrs_", "ztrtrs_",
+    "sgeev_", "dgeev_", "cgeev_", "zgeev_",
+    "cheev_", "zheev_",
     "sgetc2_", "dgetc2_", "cgetc2_", "zgetc2_",
     "sgesc2_", "dgesc2_", "cgesc2_", "zgesc2_",
 }

--- a/scripts/generate_lapack_bindings.py
+++ b/scripts/generate_lapack_bindings.py
@@ -245,30 +245,43 @@ def generate_fortran_export(func: Function) -> str:
     lp64_params = []
     ilp64_lines = []
     ilp64_params = []
+    lp64_writeback = []
+    ilp64_writeback = []
     for p in func.params:
         if p.type_.startswith('*const c_int'):
             lp64_name = f"{p.name}_lp64"
             ilp64_name = f"{p.name}_ilp64"
-            lp64_lines.append(f"            let {lp64_name}: *const i32 = {p.name} as *const i32;")
-            ilp64_lines.append(f"            let {ilp64_name}: *const i64 = {p.name} as *const i64;")
-            lp64_params.append(lp64_name)
-            ilp64_params.append(ilp64_name)
+            lp64_lines.append(f"            let {lp64_name}: i32 = *{p.name} as i32;")
+            ilp64_lines.append(f"            let {ilp64_name}: i64 = *{p.name} as i64;")
+            lp64_params.append(f"&{lp64_name}")
+            ilp64_params.append(f"&{ilp64_name}")
         elif p.type_.startswith('*mut c_int'):
             lp64_name = f"{p.name}_lp64"
             ilp64_name = f"{p.name}_ilp64"
-            lp64_lines.append(f"            let {lp64_name}: *mut i32 = {p.name} as *mut i32;")
-            ilp64_lines.append(f"            let {ilp64_name}: *mut i64 = {p.name} as *mut i64;")
-            lp64_params.append(lp64_name)
-            ilp64_params.append(ilp64_name)
+            lp64_lines.append(f"            let mut {lp64_name}: i32 = *{p.name} as i32;")
+            ilp64_lines.append(f"            let mut {ilp64_name}: i64 = *{p.name} as i64;")
+            lp64_params.append(f"&mut {lp64_name}")
+            ilp64_params.append(f"&mut {ilp64_name}")
+            lp64_writeback.append(f"            *{p.name} = {lp64_name} as lapackint;")
+            ilp64_writeback.append(f"            *{p.name} = {ilp64_name} as lapackint;")
         else:
             lp64_params.append(p.name)
             ilp64_params.append(p.name)
 
-    params_str = ',\n'.join(params)
-    lp64_calls_str = ', '.join(lp64_params)
-    ilp64_calls_str = ', '.join(ilp64_params)
+    lp64_wb_str = '\n'.join(lp64_writeback)
+    ilp64_wb_str = '\n'.join(ilp64_writeback)
     lp64_lines_str = '\n'.join(lp64_lines)
     ilp64_lines_str = '\n'.join(ilp64_lines)
+    lp64_calls_str = ', '.join(lp64_params)
+    ilp64_calls_str = ', '.join(ilp64_params)
+    params_str = ',\n'.join(params)
+
+    has_lp64_wb = bool(lp64_writeback)
+    has_ilp64_wb = bool(ilp64_writeback)
+    lp64_call_block = f"""            fun({lp64_calls_str})""" + (f""";
+{lp64_wb_str}""" if has_lp64_wb else "")
+    ilp64_call_block = f"""            fun({ilp64_calls_str})""" + (f""";
+{ilp64_wb_str}""" if has_ilp64_wb else "")
 
     return f"""#[no_mangle]
 pub unsafe extern "C" fn {func.name}(
@@ -281,11 +294,11 @@ pub unsafe extern "C" fn {func.name}(
     match provider {{
         {provider_name}::Lp64(fun) => {{
 {lp64_lines_str}
-            fun({lp64_calls_str})
+{lp64_call_block}
         }}
         {provider_name}::Ilp64(fun) => {{
 {ilp64_lines_str}
-            fun({ilp64_calls_str})
+{ilp64_call_block}
         }}
     }}
 }}"""

--- a/src/backend_gen.rs
+++ b/src/backend_gen.rs
@@ -1,5 +1,61 @@
 // Auto-generated: LP64/ILP64 dual function pointer types.
 
+pub type CgeevLp64FnPtr = unsafe extern "C" fn(
+    jobvl: *const c_char,
+    jobvr: *const c_char,
+    n: *const i32,
+    A: *mut num_complex::Complex32,
+    lda: *const i32,
+    W: *mut num_complex::Complex32,
+    VL: *mut num_complex::Complex32,
+    ldvl: *const i32,
+    VR: *mut num_complex::Complex32,
+    ldvr: *const i32,
+    work: *mut num_complex::Complex32,
+    lwork: *const i32,
+    rwork: *mut f32,
+    info: *mut i32,
+);
+pub type CgeevIlp64FnPtr = unsafe extern "C" fn(
+    jobvl: *const c_char,
+    jobvr: *const c_char,
+    n: *const i64,
+    A: *mut num_complex::Complex32,
+    lda: *const i64,
+    W: *mut num_complex::Complex32,
+    VL: *mut num_complex::Complex32,
+    ldvl: *const i64,
+    VR: *mut num_complex::Complex32,
+    ldvr: *const i64,
+    work: *mut num_complex::Complex32,
+    lwork: *const i64,
+    rwork: *mut f32,
+    info: *mut i64,
+);
+define_dual_backend!(cgeev, CgeevLp64FnPtr, CgeevIlp64FnPtr);
+
+pub type CgeqrfLp64FnPtr = unsafe extern "C" fn(
+    m: *const i32,
+    n: *const i32,
+    A: *mut num_complex::Complex32,
+    lda: *const i32,
+    tau: *mut num_complex::Complex32,
+    work: *mut num_complex::Complex32,
+    lwork: *const i32,
+    info: *mut i32,
+);
+pub type CgeqrfIlp64FnPtr = unsafe extern "C" fn(
+    m: *const i64,
+    n: *const i64,
+    A: *mut num_complex::Complex32,
+    lda: *const i64,
+    tau: *mut num_complex::Complex32,
+    work: *mut num_complex::Complex32,
+    lwork: *const i64,
+    info: *mut i64,
+);
+define_dual_backend!(cgeqrf, CgeqrfLp64FnPtr, CgeqrfIlp64FnPtr);
+
 pub type Cgesc2Lp64FnPtr = unsafe extern "C" fn(
     n: *const i32,
     A: *const num_complex::Complex32,
@@ -158,6 +214,32 @@ pub type CgetrsIlp64FnPtr = unsafe extern "C" fn(
 );
 define_dual_backend!(cgetrs, CgetrsLp64FnPtr, CgetrsIlp64FnPtr);
 
+pub type CheevLp64FnPtr = unsafe extern "C" fn(
+    jobz: *const c_char,
+    uplo: *const c_char,
+    n: *const i32,
+    A: *mut num_complex::Complex32,
+    lda: *const i32,
+    W: *mut f32,
+    work: *mut num_complex::Complex32,
+    lwork: *const i32,
+    rwork: *mut f32,
+    info: *mut i32,
+);
+pub type CheevIlp64FnPtr = unsafe extern "C" fn(
+    jobz: *const c_char,
+    uplo: *const c_char,
+    n: *const i64,
+    A: *mut num_complex::Complex32,
+    lda: *const i64,
+    W: *mut f32,
+    work: *mut num_complex::Complex32,
+    lwork: *const i64,
+    rwork: *mut f32,
+    info: *mut i64,
+);
+define_dual_backend!(cheev, CheevLp64FnPtr, CheevIlp64FnPtr);
+
 pub type CpotrfLp64FnPtr = unsafe extern "C" fn(
     uplo: *const c_char,
     n: *const i32,
@@ -173,6 +255,112 @@ pub type CpotrfIlp64FnPtr = unsafe extern "C" fn(
     info: *mut i64,
 );
 define_dual_backend!(cpotrf, CpotrfLp64FnPtr, CpotrfIlp64FnPtr);
+
+pub type CtrtrsLp64FnPtr = unsafe extern "C" fn(
+    uplo: *const c_char,
+    trans: *const c_char,
+    diag: *const c_char,
+    n: *const i32,
+    nrhs: *const i32,
+    A: *const num_complex::Complex32,
+    lda: *const i32,
+    B: *mut num_complex::Complex32,
+    ldb: *const i32,
+    info: *mut i32,
+);
+pub type CtrtrsIlp64FnPtr = unsafe extern "C" fn(
+    uplo: *const c_char,
+    trans: *const c_char,
+    diag: *const c_char,
+    n: *const i64,
+    nrhs: *const i64,
+    A: *const num_complex::Complex32,
+    lda: *const i64,
+    B: *mut num_complex::Complex32,
+    ldb: *const i64,
+    info: *mut i64,
+);
+define_dual_backend!(ctrtrs, CtrtrsLp64FnPtr, CtrtrsIlp64FnPtr);
+
+pub type CungqrLp64FnPtr = unsafe extern "C" fn(
+    m: *const i32,
+    n: *const i32,
+    k: *const i32,
+    A: *mut num_complex::Complex32,
+    lda: *const i32,
+    tau: *const num_complex::Complex32,
+    work: *mut num_complex::Complex32,
+    lwork: *const i32,
+    info: *mut i32,
+);
+pub type CungqrIlp64FnPtr = unsafe extern "C" fn(
+    m: *const i64,
+    n: *const i64,
+    k: *const i64,
+    A: *mut num_complex::Complex32,
+    lda: *const i64,
+    tau: *const num_complex::Complex32,
+    work: *mut num_complex::Complex32,
+    lwork: *const i64,
+    info: *mut i64,
+);
+define_dual_backend!(cungqr, CungqrLp64FnPtr, CungqrIlp64FnPtr);
+
+pub type DgeevLp64FnPtr = unsafe extern "C" fn(
+    jobvl: *const c_char,
+    jobvr: *const c_char,
+    n: *const i32,
+    A: *mut f64,
+    lda: *const i32,
+    WR: *mut f64,
+    WI: *mut f64,
+    VL: *mut f64,
+    ldvl: *const i32,
+    VR: *mut f64,
+    ldvr: *const i32,
+    work: *mut f64,
+    lwork: *const i32,
+    info: *mut i32,
+);
+pub type DgeevIlp64FnPtr = unsafe extern "C" fn(
+    jobvl: *const c_char,
+    jobvr: *const c_char,
+    n: *const i64,
+    A: *mut f64,
+    lda: *const i64,
+    WR: *mut f64,
+    WI: *mut f64,
+    VL: *mut f64,
+    ldvl: *const i64,
+    VR: *mut f64,
+    ldvr: *const i64,
+    work: *mut f64,
+    lwork: *const i64,
+    info: *mut i64,
+);
+define_dual_backend!(dgeev, DgeevLp64FnPtr, DgeevIlp64FnPtr);
+
+pub type DgeqrfLp64FnPtr = unsafe extern "C" fn(
+    m: *const i32,
+    n: *const i32,
+    A: *mut f64,
+    lda: *const i32,
+    tau: *mut f64,
+    work: *mut f64,
+    lwork: *const i32,
+    info: *mut i32,
+);
+pub type DgeqrfIlp64FnPtr = unsafe extern "C" fn(
+    m: *const i64,
+    n: *const i64,
+    A: *mut f64,
+    lda: *const i64,
+    tau: *mut f64,
+    work: *mut f64,
+    lwork: *const i64,
+    info: *mut i64,
+);
+define_dual_backend!(dgeqrf, DgeqrfLp64FnPtr, DgeqrfIlp64FnPtr);
 
 pub type Dgesc2Lp64FnPtr = unsafe extern "C" fn(
     n: *const i32,
@@ -330,6 +518,30 @@ pub type DgetrsIlp64FnPtr = unsafe extern "C" fn(
 );
 define_dual_backend!(dgetrs, DgetrsLp64FnPtr, DgetrsIlp64FnPtr);
 
+pub type DorgqrLp64FnPtr = unsafe extern "C" fn(
+    m: *const i32,
+    n: *const i32,
+    k: *const i32,
+    A: *mut f64,
+    lda: *const i32,
+    tau: *const f64,
+    work: *mut f64,
+    lwork: *const i32,
+    info: *mut i32,
+);
+pub type DorgqrIlp64FnPtr = unsafe extern "C" fn(
+    m: *const i64,
+    n: *const i64,
+    k: *const i64,
+    A: *mut f64,
+    lda: *const i64,
+    tau: *const f64,
+    work: *mut f64,
+    lwork: *const i64,
+    info: *mut i64,
+);
+define_dual_backend!(dorgqr, DorgqrLp64FnPtr, DorgqrIlp64FnPtr);
+
 pub type DpotrfLp64FnPtr = unsafe extern "C" fn(
     uplo: *const c_char,
     n: *const i32,
@@ -369,6 +581,88 @@ pub type DsyevIlp64FnPtr = unsafe extern "C" fn(
     info: *mut i64,
 );
 define_dual_backend!(dsyev, DsyevLp64FnPtr, DsyevIlp64FnPtr);
+
+pub type DtrtrsLp64FnPtr = unsafe extern "C" fn(
+    uplo: *const c_char,
+    trans: *const c_char,
+    diag: *const c_char,
+    n: *const i32,
+    nrhs: *const i32,
+    A: *const f64,
+    lda: *const i32,
+    B: *mut f64,
+    ldb: *const i32,
+    info: *mut i32,
+);
+pub type DtrtrsIlp64FnPtr = unsafe extern "C" fn(
+    uplo: *const c_char,
+    trans: *const c_char,
+    diag: *const c_char,
+    n: *const i64,
+    nrhs: *const i64,
+    A: *const f64,
+    lda: *const i64,
+    B: *mut f64,
+    ldb: *const i64,
+    info: *mut i64,
+);
+define_dual_backend!(dtrtrs, DtrtrsLp64FnPtr, DtrtrsIlp64FnPtr);
+
+pub type SgeevLp64FnPtr = unsafe extern "C" fn(
+    jobvl: *const c_char,
+    jobvr: *const c_char,
+    n: *const i32,
+    A: *mut f32,
+    lda: *const i32,
+    WR: *mut f32,
+    WI: *mut f32,
+    VL: *mut f32,
+    ldvl: *const i32,
+    VR: *mut f32,
+    ldvr: *const i32,
+    work: *mut f32,
+    lwork: *const i32,
+    info: *mut i32,
+);
+pub type SgeevIlp64FnPtr = unsafe extern "C" fn(
+    jobvl: *const c_char,
+    jobvr: *const c_char,
+    n: *const i64,
+    A: *mut f32,
+    lda: *const i64,
+    WR: *mut f32,
+    WI: *mut f32,
+    VL: *mut f32,
+    ldvl: *const i64,
+    VR: *mut f32,
+    ldvr: *const i64,
+    work: *mut f32,
+    lwork: *const i64,
+    info: *mut i64,
+);
+define_dual_backend!(sgeev, SgeevLp64FnPtr, SgeevIlp64FnPtr);
+
+pub type SgeqrfLp64FnPtr = unsafe extern "C" fn(
+    m: *const i32,
+    n: *const i32,
+    A: *mut f32,
+    lda: *const i32,
+    tau: *mut f32,
+    work: *mut f32,
+    lwork: *const i32,
+    info: *mut i32,
+);
+pub type SgeqrfIlp64FnPtr = unsafe extern "C" fn(
+    m: *const i64,
+    n: *const i64,
+    A: *mut f32,
+    lda: *const i64,
+    tau: *mut f32,
+    work: *mut f32,
+    lwork: *const i64,
+    info: *mut i64,
+);
+define_dual_backend!(sgeqrf, SgeqrfLp64FnPtr, SgeqrfIlp64FnPtr);
 
 pub type Sgesc2Lp64FnPtr = unsafe extern "C" fn(
     n: *const i32,
@@ -526,6 +820,30 @@ pub type SgetrsIlp64FnPtr = unsafe extern "C" fn(
 );
 define_dual_backend!(sgetrs, SgetrsLp64FnPtr, SgetrsIlp64FnPtr);
 
+pub type SorgqrLp64FnPtr = unsafe extern "C" fn(
+    m: *const i32,
+    n: *const i32,
+    k: *const i32,
+    A: *mut f32,
+    lda: *const i32,
+    tau: *const f32,
+    work: *mut f32,
+    lwork: *const i32,
+    info: *mut i32,
+);
+pub type SorgqrIlp64FnPtr = unsafe extern "C" fn(
+    m: *const i64,
+    n: *const i64,
+    k: *const i64,
+    A: *mut f32,
+    lda: *const i64,
+    tau: *const f32,
+    work: *mut f32,
+    lwork: *const i64,
+    info: *mut i64,
+);
+define_dual_backend!(sorgqr, SorgqrLp64FnPtr, SorgqrIlp64FnPtr);
+
 pub type SpotrfLp64FnPtr = unsafe extern "C" fn(
     uplo: *const c_char,
     n: *const i32,
@@ -565,6 +883,88 @@ pub type SsyevIlp64FnPtr = unsafe extern "C" fn(
     info: *mut i64,
 );
 define_dual_backend!(ssyev, SsyevLp64FnPtr, SsyevIlp64FnPtr);
+
+pub type StrtrsLp64FnPtr = unsafe extern "C" fn(
+    uplo: *const c_char,
+    trans: *const c_char,
+    diag: *const c_char,
+    n: *const i32,
+    nrhs: *const i32,
+    A: *const f32,
+    lda: *const i32,
+    B: *mut f32,
+    ldb: *const i32,
+    info: *mut i32,
+);
+pub type StrtrsIlp64FnPtr = unsafe extern "C" fn(
+    uplo: *const c_char,
+    trans: *const c_char,
+    diag: *const c_char,
+    n: *const i64,
+    nrhs: *const i64,
+    A: *const f32,
+    lda: *const i64,
+    B: *mut f32,
+    ldb: *const i64,
+    info: *mut i64,
+);
+define_dual_backend!(strtrs, StrtrsLp64FnPtr, StrtrsIlp64FnPtr);
+
+pub type ZgeevLp64FnPtr = unsafe extern "C" fn(
+    jobvl: *const c_char,
+    jobvr: *const c_char,
+    n: *const i32,
+    A: *mut num_complex::Complex64,
+    lda: *const i32,
+    W: *mut num_complex::Complex64,
+    VL: *mut num_complex::Complex64,
+    ldvl: *const i32,
+    VR: *mut num_complex::Complex64,
+    ldvr: *const i32,
+    work: *mut num_complex::Complex64,
+    lwork: *const i32,
+    rwork: *mut f64,
+    info: *mut i32,
+);
+pub type ZgeevIlp64FnPtr = unsafe extern "C" fn(
+    jobvl: *const c_char,
+    jobvr: *const c_char,
+    n: *const i64,
+    A: *mut num_complex::Complex64,
+    lda: *const i64,
+    W: *mut num_complex::Complex64,
+    VL: *mut num_complex::Complex64,
+    ldvl: *const i64,
+    VR: *mut num_complex::Complex64,
+    ldvr: *const i64,
+    work: *mut num_complex::Complex64,
+    lwork: *const i64,
+    rwork: *mut f64,
+    info: *mut i64,
+);
+define_dual_backend!(zgeev, ZgeevLp64FnPtr, ZgeevIlp64FnPtr);
+
+pub type ZgeqrfLp64FnPtr = unsafe extern "C" fn(
+    m: *const i32,
+    n: *const i32,
+    A: *mut num_complex::Complex64,
+    lda: *const i32,
+    tau: *mut num_complex::Complex64,
+    work: *mut num_complex::Complex64,
+    lwork: *const i32,
+    info: *mut i32,
+);
+pub type ZgeqrfIlp64FnPtr = unsafe extern "C" fn(
+    m: *const i64,
+    n: *const i64,
+    A: *mut num_complex::Complex64,
+    lda: *const i64,
+    tau: *mut num_complex::Complex64,
+    work: *mut num_complex::Complex64,
+    lwork: *const i64,
+    info: *mut i64,
+);
+define_dual_backend!(zgeqrf, ZgeqrfLp64FnPtr, ZgeqrfIlp64FnPtr);
 
 pub type Zgesc2Lp64FnPtr = unsafe extern "C" fn(
     n: *const i32,
@@ -724,6 +1124,32 @@ pub type ZgetrsIlp64FnPtr = unsafe extern "C" fn(
 );
 define_dual_backend!(zgetrs, ZgetrsLp64FnPtr, ZgetrsIlp64FnPtr);
 
+pub type ZheevLp64FnPtr = unsafe extern "C" fn(
+    jobz: *const c_char,
+    uplo: *const c_char,
+    n: *const i32,
+    A: *mut num_complex::Complex64,
+    lda: *const i32,
+    W: *mut f64,
+    work: *mut num_complex::Complex64,
+    lwork: *const i32,
+    rwork: *mut f64,
+    info: *mut i32,
+);
+pub type ZheevIlp64FnPtr = unsafe extern "C" fn(
+    jobz: *const c_char,
+    uplo: *const c_char,
+    n: *const i64,
+    A: *mut num_complex::Complex64,
+    lda: *const i64,
+    W: *mut f64,
+    work: *mut num_complex::Complex64,
+    lwork: *const i64,
+    rwork: *mut f64,
+    info: *mut i64,
+);
+define_dual_backend!(zheev, ZheevLp64FnPtr, ZheevIlp64FnPtr);
+
 pub type ZpotrfLp64FnPtr = unsafe extern "C" fn(
     uplo: *const c_char,
     n: *const i32,
@@ -739,3 +1165,53 @@ pub type ZpotrfIlp64FnPtr = unsafe extern "C" fn(
     info: *mut i64,
 );
 define_dual_backend!(zpotrf, ZpotrfLp64FnPtr, ZpotrfIlp64FnPtr);
+
+pub type ZtrtrsLp64FnPtr = unsafe extern "C" fn(
+    uplo: *const c_char,
+    trans: *const c_char,
+    diag: *const c_char,
+    n: *const i32,
+    nrhs: *const i32,
+    A: *const num_complex::Complex64,
+    lda: *const i32,
+    B: *mut num_complex::Complex64,
+    ldb: *const i32,
+    info: *mut i32,
+);
+pub type ZtrtrsIlp64FnPtr = unsafe extern "C" fn(
+    uplo: *const c_char,
+    trans: *const c_char,
+    diag: *const c_char,
+    n: *const i64,
+    nrhs: *const i64,
+    A: *const num_complex::Complex64,
+    lda: *const i64,
+    B: *mut num_complex::Complex64,
+    ldb: *const i64,
+    info: *mut i64,
+);
+define_dual_backend!(ztrtrs, ZtrtrsLp64FnPtr, ZtrtrsIlp64FnPtr);
+
+pub type ZungqrLp64FnPtr = unsafe extern "C" fn(
+    m: *const i32,
+    n: *const i32,
+    k: *const i32,
+    A: *mut num_complex::Complex64,
+    lda: *const i32,
+    tau: *const num_complex::Complex64,
+    work: *mut num_complex::Complex64,
+    lwork: *const i32,
+    info: *mut i32,
+);
+pub type ZungqrIlp64FnPtr = unsafe extern "C" fn(
+    m: *const i64,
+    n: *const i64,
+    k: *const i64,
+    A: *mut num_complex::Complex64,
+    lda: *const i64,
+    tau: *const num_complex::Complex64,
+    work: *mut num_complex::Complex64,
+    lwork: *const i64,
+    info: *mut i64,
+);
+define_dual_backend!(zungqr, ZungqrLp64FnPtr, ZungqrIlp64FnPtr);

--- a/src/fortran_gen.rs
+++ b/src/fortran_gen.rs
@@ -1,6 +1,84 @@
 // Auto-generated: Fortran LAPACK symbol exports with dual LP64/ILP64 dispatch.
 
 #[no_mangle]
+pub unsafe extern "C" fn cgeev_(
+    jobvl: *const c_char,
+    jobvr: *const c_char,
+    n: *const lapackint,
+    A: *mut Complex32,
+    lda: *const lapackint,
+    W: *mut Complex32,
+    VL: *mut Complex32,
+    ldvl: *const lapackint,
+    VR: *mut Complex32,
+    ldvr: *const lapackint,
+    work: *mut Complex32,
+    lwork: *const lapackint,
+    rwork: *mut f32,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_cgeev_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_cgeev_for_lp64();
+    match provider {
+        CgeevProvider::Lp64(fun) => {
+            let n_lp64: *const i32 = n as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let ldvl_lp64: *const i32 = ldvl as *const i32;
+            let ldvr_lp64: *const i32 = ldvr as *const i32;
+            let lwork_lp64: *const i32 = lwork as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(jobvl, jobvr, n_lp64, A, lda_lp64, W, VL, ldvl_lp64, VR, ldvr_lp64, work, lwork_lp64, rwork, info_lp64)
+        }
+        CgeevProvider::Ilp64(fun) => {
+            let n_ilp64: *const i64 = n as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let ldvl_ilp64: *const i64 = ldvl as *const i64;
+            let ldvr_ilp64: *const i64 = ldvr as *const i64;
+            let lwork_ilp64: *const i64 = lwork as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(jobvl, jobvr, n_ilp64, A, lda_ilp64, W, VL, ldvl_ilp64, VR, ldvr_ilp64, work, lwork_ilp64, rwork, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cgeqrf_(
+    m: *const lapackint,
+    n: *const lapackint,
+    A: *mut Complex32,
+    lda: *const lapackint,
+    tau: *mut Complex32,
+    work: *mut Complex32,
+    lwork: *const lapackint,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_cgeqrf_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_cgeqrf_for_lp64();
+    match provider {
+        CgeqrfProvider::Lp64(fun) => {
+            let m_lp64: *const i32 = m as *const i32;
+            let n_lp64: *const i32 = n as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let lwork_lp64: *const i32 = lwork as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(m_lp64, n_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+        }
+        CgeqrfProvider::Ilp64(fun) => {
+            let m_ilp64: *const i64 = m as *const i64;
+            let n_ilp64: *const i64 = n as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let lwork_ilp64: *const i64 = lwork as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(m_ilp64, n_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn cgesc2_(
     n: *const lapackint,
     A: *const Complex32,
@@ -254,6 +332,41 @@ pub unsafe extern "C" fn cgetrs_(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn cheev_(
+    jobz: *const c_char,
+    uplo: *const c_char,
+    n: *const lapackint,
+    A: *mut Complex32,
+    lda: *const lapackint,
+    W: *mut f32,
+    work: *mut Complex32,
+    lwork: *const lapackint,
+    rwork: *mut f32,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_cheev_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_cheev_for_lp64();
+    match provider {
+        CheevProvider::Lp64(fun) => {
+            let n_lp64: *const i32 = n as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let lwork_lp64: *const i32 = lwork as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(jobz, uplo, n_lp64, A, lda_lp64, W, work, lwork_lp64, rwork, info_lp64)
+        }
+        CheevProvider::Ilp64(fun) => {
+            let n_ilp64: *const i64 = n as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let lwork_ilp64: *const i64 = lwork as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(jobz, uplo, n_ilp64, A, lda_ilp64, W, work, lwork_ilp64, rwork, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn cpotrf_(
     uplo: *const c_char,
     n: *const lapackint,
@@ -277,6 +390,159 @@ pub unsafe extern "C" fn cpotrf_(
             let lda_ilp64: *const i64 = lda as *const i64;
             let info_ilp64: *mut i64 = info as *mut i64;
             fun(uplo, n_ilp64, A, lda_ilp64, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ctrtrs_(
+    uplo: *const c_char,
+    trans: *const c_char,
+    diag: *const c_char,
+    n: *const lapackint,
+    nrhs: *const lapackint,
+    A: *const Complex32,
+    lda: *const lapackint,
+    B: *mut Complex32,
+    ldb: *const lapackint,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_ctrtrs_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_ctrtrs_for_lp64();
+    match provider {
+        CtrtrsProvider::Lp64(fun) => {
+            let n_lp64: *const i32 = n as *const i32;
+            let nrhs_lp64: *const i32 = nrhs as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let ldb_lp64: *const i32 = ldb as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(uplo, trans, diag, n_lp64, nrhs_lp64, A, lda_lp64, B, ldb_lp64, info_lp64)
+        }
+        CtrtrsProvider::Ilp64(fun) => {
+            let n_ilp64: *const i64 = n as *const i64;
+            let nrhs_ilp64: *const i64 = nrhs as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let ldb_ilp64: *const i64 = ldb as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(uplo, trans, diag, n_ilp64, nrhs_ilp64, A, lda_ilp64, B, ldb_ilp64, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cungqr_(
+    m: *const lapackint,
+    n: *const lapackint,
+    k: *const lapackint,
+    A: *mut Complex32,
+    lda: *const lapackint,
+    tau: *const Complex32,
+    work: *mut Complex32,
+    lwork: *const lapackint,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_cungqr_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_cungqr_for_lp64();
+    match provider {
+        CungqrProvider::Lp64(fun) => {
+            let m_lp64: *const i32 = m as *const i32;
+            let n_lp64: *const i32 = n as *const i32;
+            let k_lp64: *const i32 = k as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let lwork_lp64: *const i32 = lwork as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(m_lp64, n_lp64, k_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+        }
+        CungqrProvider::Ilp64(fun) => {
+            let m_ilp64: *const i64 = m as *const i64;
+            let n_ilp64: *const i64 = n as *const i64;
+            let k_ilp64: *const i64 = k as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let lwork_ilp64: *const i64 = lwork as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(m_ilp64, n_ilp64, k_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dgeev_(
+    jobvl: *const c_char,
+    jobvr: *const c_char,
+    n: *const lapackint,
+    A: *mut f64,
+    lda: *const lapackint,
+    WR: *mut f64,
+    WI: *mut f64,
+    VL: *mut f64,
+    ldvl: *const lapackint,
+    VR: *mut f64,
+    ldvr: *const lapackint,
+    work: *mut f64,
+    lwork: *const lapackint,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_dgeev_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_dgeev_for_lp64();
+    match provider {
+        DgeevProvider::Lp64(fun) => {
+            let n_lp64: *const i32 = n as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let ldvl_lp64: *const i32 = ldvl as *const i32;
+            let ldvr_lp64: *const i32 = ldvr as *const i32;
+            let lwork_lp64: *const i32 = lwork as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(jobvl, jobvr, n_lp64, A, lda_lp64, WR, WI, VL, ldvl_lp64, VR, ldvr_lp64, work, lwork_lp64, info_lp64)
+        }
+        DgeevProvider::Ilp64(fun) => {
+            let n_ilp64: *const i64 = n as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let ldvl_ilp64: *const i64 = ldvl as *const i64;
+            let ldvr_ilp64: *const i64 = ldvr as *const i64;
+            let lwork_ilp64: *const i64 = lwork as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(jobvl, jobvr, n_ilp64, A, lda_ilp64, WR, WI, VL, ldvl_ilp64, VR, ldvr_ilp64, work, lwork_ilp64, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dgeqrf_(
+    m: *const lapackint,
+    n: *const lapackint,
+    A: *mut f64,
+    lda: *const lapackint,
+    tau: *mut f64,
+    work: *mut f64,
+    lwork: *const lapackint,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_dgeqrf_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_dgeqrf_for_lp64();
+    match provider {
+        DgeqrfProvider::Lp64(fun) => {
+            let m_lp64: *const i32 = m as *const i32;
+            let n_lp64: *const i32 = n as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let lwork_lp64: *const i32 = lwork as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(m_lp64, n_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+        }
+        DgeqrfProvider::Ilp64(fun) => {
+            let m_ilp64: *const i64 = m as *const i64;
+            let n_ilp64: *const i64 = n as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let lwork_ilp64: *const i64 = lwork as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(m_ilp64, n_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
         }
     }
 }
@@ -534,6 +800,44 @@ pub unsafe extern "C" fn dgetrs_(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dorgqr_(
+    m: *const lapackint,
+    n: *const lapackint,
+    k: *const lapackint,
+    A: *mut f64,
+    lda: *const lapackint,
+    tau: *const f64,
+    work: *mut f64,
+    lwork: *const lapackint,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_dorgqr_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_dorgqr_for_lp64();
+    match provider {
+        DorgqrProvider::Lp64(fun) => {
+            let m_lp64: *const i32 = m as *const i32;
+            let n_lp64: *const i32 = n as *const i32;
+            let k_lp64: *const i32 = k as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let lwork_lp64: *const i32 = lwork as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(m_lp64, n_lp64, k_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+        }
+        DorgqrProvider::Ilp64(fun) => {
+            let m_ilp64: *const i64 = m as *const i64;
+            let n_ilp64: *const i64 = n as *const i64;
+            let k_ilp64: *const i64 = k as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let lwork_ilp64: *const i64 = lwork as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(m_ilp64, n_ilp64, k_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dpotrf_(
     uplo: *const c_char,
     n: *const lapackint,
@@ -591,6 +895,121 @@ pub unsafe extern "C" fn dsyev_(
             let lwork_ilp64: *const i64 = lwork as *const i64;
             let info_ilp64: *mut i64 = info as *mut i64;
             fun(jobz, uplo, n_ilp64, A, lda_ilp64, W, work, lwork_ilp64, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dtrtrs_(
+    uplo: *const c_char,
+    trans: *const c_char,
+    diag: *const c_char,
+    n: *const lapackint,
+    nrhs: *const lapackint,
+    A: *const f64,
+    lda: *const lapackint,
+    B: *mut f64,
+    ldb: *const lapackint,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_dtrtrs_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_dtrtrs_for_lp64();
+    match provider {
+        DtrtrsProvider::Lp64(fun) => {
+            let n_lp64: *const i32 = n as *const i32;
+            let nrhs_lp64: *const i32 = nrhs as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let ldb_lp64: *const i32 = ldb as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(uplo, trans, diag, n_lp64, nrhs_lp64, A, lda_lp64, B, ldb_lp64, info_lp64)
+        }
+        DtrtrsProvider::Ilp64(fun) => {
+            let n_ilp64: *const i64 = n as *const i64;
+            let nrhs_ilp64: *const i64 = nrhs as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let ldb_ilp64: *const i64 = ldb as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(uplo, trans, diag, n_ilp64, nrhs_ilp64, A, lda_ilp64, B, ldb_ilp64, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sgeev_(
+    jobvl: *const c_char,
+    jobvr: *const c_char,
+    n: *const lapackint,
+    A: *mut f32,
+    lda: *const lapackint,
+    WR: *mut f32,
+    WI: *mut f32,
+    VL: *mut f32,
+    ldvl: *const lapackint,
+    VR: *mut f32,
+    ldvr: *const lapackint,
+    work: *mut f32,
+    lwork: *const lapackint,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_sgeev_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_sgeev_for_lp64();
+    match provider {
+        SgeevProvider::Lp64(fun) => {
+            let n_lp64: *const i32 = n as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let ldvl_lp64: *const i32 = ldvl as *const i32;
+            let ldvr_lp64: *const i32 = ldvr as *const i32;
+            let lwork_lp64: *const i32 = lwork as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(jobvl, jobvr, n_lp64, A, lda_lp64, WR, WI, VL, ldvl_lp64, VR, ldvr_lp64, work, lwork_lp64, info_lp64)
+        }
+        SgeevProvider::Ilp64(fun) => {
+            let n_ilp64: *const i64 = n as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let ldvl_ilp64: *const i64 = ldvl as *const i64;
+            let ldvr_ilp64: *const i64 = ldvr as *const i64;
+            let lwork_ilp64: *const i64 = lwork as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(jobvl, jobvr, n_ilp64, A, lda_ilp64, WR, WI, VL, ldvl_ilp64, VR, ldvr_ilp64, work, lwork_ilp64, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sgeqrf_(
+    m: *const lapackint,
+    n: *const lapackint,
+    A: *mut f32,
+    lda: *const lapackint,
+    tau: *mut f32,
+    work: *mut f32,
+    lwork: *const lapackint,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_sgeqrf_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_sgeqrf_for_lp64();
+    match provider {
+        SgeqrfProvider::Lp64(fun) => {
+            let m_lp64: *const i32 = m as *const i32;
+            let n_lp64: *const i32 = n as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let lwork_lp64: *const i32 = lwork as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(m_lp64, n_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+        }
+        SgeqrfProvider::Ilp64(fun) => {
+            let m_ilp64: *const i64 = m as *const i64;
+            let n_ilp64: *const i64 = n as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let lwork_ilp64: *const i64 = lwork as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(m_ilp64, n_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
         }
     }
 }
@@ -848,6 +1267,44 @@ pub unsafe extern "C" fn sgetrs_(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn sorgqr_(
+    m: *const lapackint,
+    n: *const lapackint,
+    k: *const lapackint,
+    A: *mut f32,
+    lda: *const lapackint,
+    tau: *const f32,
+    work: *mut f32,
+    lwork: *const lapackint,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_sorgqr_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_sorgqr_for_lp64();
+    match provider {
+        SorgqrProvider::Lp64(fun) => {
+            let m_lp64: *const i32 = m as *const i32;
+            let n_lp64: *const i32 = n as *const i32;
+            let k_lp64: *const i32 = k as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let lwork_lp64: *const i32 = lwork as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(m_lp64, n_lp64, k_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+        }
+        SorgqrProvider::Ilp64(fun) => {
+            let m_ilp64: *const i64 = m as *const i64;
+            let n_ilp64: *const i64 = n as *const i64;
+            let k_ilp64: *const i64 = k as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let lwork_ilp64: *const i64 = lwork as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(m_ilp64, n_ilp64, k_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn spotrf_(
     uplo: *const c_char,
     n: *const lapackint,
@@ -905,6 +1362,121 @@ pub unsafe extern "C" fn ssyev_(
             let lwork_ilp64: *const i64 = lwork as *const i64;
             let info_ilp64: *mut i64 = info as *mut i64;
             fun(jobz, uplo, n_ilp64, A, lda_ilp64, W, work, lwork_ilp64, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn strtrs_(
+    uplo: *const c_char,
+    trans: *const c_char,
+    diag: *const c_char,
+    n: *const lapackint,
+    nrhs: *const lapackint,
+    A: *const f32,
+    lda: *const lapackint,
+    B: *mut f32,
+    ldb: *const lapackint,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_strtrs_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_strtrs_for_lp64();
+    match provider {
+        StrtrsProvider::Lp64(fun) => {
+            let n_lp64: *const i32 = n as *const i32;
+            let nrhs_lp64: *const i32 = nrhs as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let ldb_lp64: *const i32 = ldb as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(uplo, trans, diag, n_lp64, nrhs_lp64, A, lda_lp64, B, ldb_lp64, info_lp64)
+        }
+        StrtrsProvider::Ilp64(fun) => {
+            let n_ilp64: *const i64 = n as *const i64;
+            let nrhs_ilp64: *const i64 = nrhs as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let ldb_ilp64: *const i64 = ldb as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(uplo, trans, diag, n_ilp64, nrhs_ilp64, A, lda_ilp64, B, ldb_ilp64, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn zgeev_(
+    jobvl: *const c_char,
+    jobvr: *const c_char,
+    n: *const lapackint,
+    A: *mut Complex64,
+    lda: *const lapackint,
+    W: *mut Complex64,
+    VL: *mut Complex64,
+    ldvl: *const lapackint,
+    VR: *mut Complex64,
+    ldvr: *const lapackint,
+    work: *mut Complex64,
+    lwork: *const lapackint,
+    rwork: *mut f64,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_zgeev_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_zgeev_for_lp64();
+    match provider {
+        ZgeevProvider::Lp64(fun) => {
+            let n_lp64: *const i32 = n as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let ldvl_lp64: *const i32 = ldvl as *const i32;
+            let ldvr_lp64: *const i32 = ldvr as *const i32;
+            let lwork_lp64: *const i32 = lwork as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(jobvl, jobvr, n_lp64, A, lda_lp64, W, VL, ldvl_lp64, VR, ldvr_lp64, work, lwork_lp64, rwork, info_lp64)
+        }
+        ZgeevProvider::Ilp64(fun) => {
+            let n_ilp64: *const i64 = n as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let ldvl_ilp64: *const i64 = ldvl as *const i64;
+            let ldvr_ilp64: *const i64 = ldvr as *const i64;
+            let lwork_ilp64: *const i64 = lwork as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(jobvl, jobvr, n_ilp64, A, lda_ilp64, W, VL, ldvl_ilp64, VR, ldvr_ilp64, work, lwork_ilp64, rwork, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn zgeqrf_(
+    m: *const lapackint,
+    n: *const lapackint,
+    A: *mut Complex64,
+    lda: *const lapackint,
+    tau: *mut Complex64,
+    work: *mut Complex64,
+    lwork: *const lapackint,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_zgeqrf_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_zgeqrf_for_lp64();
+    match provider {
+        ZgeqrfProvider::Lp64(fun) => {
+            let m_lp64: *const i32 = m as *const i32;
+            let n_lp64: *const i32 = n as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let lwork_lp64: *const i32 = lwork as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(m_lp64, n_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+        }
+        ZgeqrfProvider::Ilp64(fun) => {
+            let m_ilp64: *const i64 = m as *const i64;
+            let n_ilp64: *const i64 = n as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let lwork_ilp64: *const i64 = lwork as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(m_ilp64, n_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
         }
     }
 }
@@ -1163,6 +1735,41 @@ pub unsafe extern "C" fn zgetrs_(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn zheev_(
+    jobz: *const c_char,
+    uplo: *const c_char,
+    n: *const lapackint,
+    A: *mut Complex64,
+    lda: *const lapackint,
+    W: *mut f64,
+    work: *mut Complex64,
+    lwork: *const lapackint,
+    rwork: *mut f64,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_zheev_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_zheev_for_lp64();
+    match provider {
+        ZheevProvider::Lp64(fun) => {
+            let n_lp64: *const i32 = n as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let lwork_lp64: *const i32 = lwork as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(jobz, uplo, n_lp64, A, lda_lp64, W, work, lwork_lp64, rwork, info_lp64)
+        }
+        ZheevProvider::Ilp64(fun) => {
+            let n_ilp64: *const i64 = n as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let lwork_ilp64: *const i64 = lwork as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(jobz, uplo, n_ilp64, A, lda_ilp64, W, work, lwork_ilp64, rwork, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn zpotrf_(
     uplo: *const c_char,
     n: *const lapackint,
@@ -1186,6 +1793,81 @@ pub unsafe extern "C" fn zpotrf_(
             let lda_ilp64: *const i64 = lda as *const i64;
             let info_ilp64: *mut i64 = info as *mut i64;
             fun(uplo, n_ilp64, A, lda_ilp64, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ztrtrs_(
+    uplo: *const c_char,
+    trans: *const c_char,
+    diag: *const c_char,
+    n: *const lapackint,
+    nrhs: *const lapackint,
+    A: *const Complex64,
+    lda: *const lapackint,
+    B: *mut Complex64,
+    ldb: *const lapackint,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_ztrtrs_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_ztrtrs_for_lp64();
+    match provider {
+        ZtrtrsProvider::Lp64(fun) => {
+            let n_lp64: *const i32 = n as *const i32;
+            let nrhs_lp64: *const i32 = nrhs as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let ldb_lp64: *const i32 = ldb as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(uplo, trans, diag, n_lp64, nrhs_lp64, A, lda_lp64, B, ldb_lp64, info_lp64)
+        }
+        ZtrtrsProvider::Ilp64(fun) => {
+            let n_ilp64: *const i64 = n as *const i64;
+            let nrhs_ilp64: *const i64 = nrhs as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let ldb_ilp64: *const i64 = ldb as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(uplo, trans, diag, n_ilp64, nrhs_ilp64, A, lda_ilp64, B, ldb_ilp64, info_ilp64)
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn zungqr_(
+    m: *const lapackint,
+    n: *const lapackint,
+    k: *const lapackint,
+    A: *mut Complex64,
+    lda: *const lapackint,
+    tau: *const Complex64,
+    work: *mut Complex64,
+    lwork: *const lapackint,
+    info: *mut lapackint,
+) {
+    #[cfg(feature = "ilp64")]
+    let provider = get_zungqr_for_ilp64();
+    #[cfg(not(feature = "ilp64"))]
+    let provider = get_zungqr_for_lp64();
+    match provider {
+        ZungqrProvider::Lp64(fun) => {
+            let m_lp64: *const i32 = m as *const i32;
+            let n_lp64: *const i32 = n as *const i32;
+            let k_lp64: *const i32 = k as *const i32;
+            let lda_lp64: *const i32 = lda as *const i32;
+            let lwork_lp64: *const i32 = lwork as *const i32;
+            let info_lp64: *mut i32 = info as *mut i32;
+            fun(m_lp64, n_lp64, k_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+        }
+        ZungqrProvider::Ilp64(fun) => {
+            let m_ilp64: *const i64 = m as *const i64;
+            let n_ilp64: *const i64 = n as *const i64;
+            let k_ilp64: *const i64 = k as *const i64;
+            let lda_ilp64: *const i64 = lda as *const i64;
+            let lwork_ilp64: *const i64 = lwork as *const i64;
+            let info_ilp64: *mut i64 = info as *mut i64;
+            fun(m_ilp64, n_ilp64, k_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
         }
     }
 }

--- a/src/fortran_gen.rs
+++ b/src/fortran_gen.rs
@@ -100,16 +100,44 @@ pub unsafe extern "C" fn cgesc2_(
         Cgesc2Provider::Lp64(fun) => {
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let ipiv_lp64: i32 = *ipiv as i32;
-            let jpiv_lp64: i32 = *jpiv as i32;
-            fun(&n_lp64, A, &lda_lp64, rhs, &ipiv_lp64, &jpiv_lp64, scale)
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec: Vec<i32> = (0..n_ipiv_lp64).map(|i| *ipiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_ptr();
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_lp64_vec_ptr = jpiv;
+            #[cfg(feature = "ilp64")]
+            let n_jpiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let jpiv_lp64_vec: Vec<i32> = (0..n_jpiv_lp64).map(|i| *jpiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let jpiv_lp64_vec_ptr = jpiv_lp64_vec.as_ptr();
+            fun(&n_lp64, A, &lda_lp64, rhs, ipiv_lp64_vec_ptr, jpiv_lp64_vec_ptr, scale)
         }
         Cgesc2Provider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let ipiv_ilp64: i64 = *ipiv as i64;
-            let jpiv_ilp64: i64 = *jpiv as i64;
-            fun(&n_ilp64, A, &lda_ilp64, rhs, &ipiv_ilp64, &jpiv_ilp64, scale)
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec: Vec<i64> = (0..n_ipiv_ilp64).map(|i| *ipiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_ptr();
+            #[cfg(feature = "ilp64")]
+            let jpiv_ilp64_vec_ptr = jpiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_jpiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_ilp64_vec: Vec<i64> = (0..n_jpiv_ilp64).map(|i| *jpiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_ilp64_vec_ptr = jpiv_ilp64_vec.as_ptr();
+            fun(&n_ilp64, A, &lda_ilp64, rhs, ipiv_ilp64_vec_ptr, jpiv_ilp64_vec_ptr, scale)
         }
     }
 }
@@ -134,22 +162,38 @@ pub unsafe extern "C" fn cgesv_(
             let n_lp64: i32 = *n as i32;
             let nrhs_lp64: i32 = *nrhs as i32;
             let lda_lp64: i32 = *lda as i32;
-            let mut ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let mut ipiv_lp64_vec: Vec<i32> = vec![0i32; n_ipiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_mut_ptr();
             let ldb_lp64: i32 = *ldb as i32;
             let mut info_lp64: i32 = *info as i32;
-            fun(&n_lp64, &nrhs_lp64, A, &lda_lp64, &mut ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
-            *ipiv = ipiv_lp64 as lapackint;
+            fun(&n_lp64, &nrhs_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, B, &ldb_lp64, &mut info_lp64);
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_ipiv_lp64 { *ipiv.add(i) = ipiv_lp64_vec[i] as lapackint; }
             *info = info_lp64 as lapackint;
         }
         CgesvProvider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let nrhs_ilp64: i64 = *nrhs as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut ipiv_ilp64_vec: Vec<i64> = vec![0i64; n_ipiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_mut_ptr();
             let ldb_ilp64: i64 = *ldb as i64;
             let mut info_ilp64: i64 = *info as i64;
-            fun(&n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
-            *ipiv = ipiv_ilp64 as lapackint;
+            fun(&n_ilp64, &nrhs_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, B, &ldb_ilp64, &mut info_ilp64);
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_ipiv_ilp64 { *ipiv.add(i) = ipiv_ilp64_vec[i] as lapackint; }
             *info = info_ilp64 as lapackint;
         }
     }
@@ -220,23 +264,55 @@ pub unsafe extern "C" fn cgetc2_(
         Cgetc2Provider::Lp64(fun) => {
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let mut ipiv_lp64: i32 = *ipiv as i32;
-            let mut jpiv_lp64: i32 = *jpiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let mut ipiv_lp64_vec: Vec<i32> = vec![0i32; n_ipiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_mut_ptr();
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_lp64_vec_ptr = jpiv;
+            #[cfg(feature = "ilp64")]
+            let n_jpiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let mut jpiv_lp64_vec: Vec<i32> = vec![0i32; n_jpiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let jpiv_lp64_vec_ptr = jpiv_lp64_vec.as_mut_ptr();
             let mut info_lp64: i32 = *info as i32;
-            fun(&n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut jpiv_lp64, &mut info_lp64);
-            *ipiv = ipiv_lp64 as lapackint;
-            *jpiv = jpiv_lp64 as lapackint;
+            fun(&n_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, jpiv_lp64_vec_ptr, &mut info_lp64);
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_ipiv_lp64 { *ipiv.add(i) = ipiv_lp64_vec[i] as lapackint; }
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_jpiv_lp64 { *jpiv.add(i) = jpiv_lp64_vec[i] as lapackint; }
             *info = info_lp64 as lapackint;
         }
         Cgetc2Provider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let mut ipiv_ilp64: i64 = *ipiv as i64;
-            let mut jpiv_ilp64: i64 = *jpiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut ipiv_ilp64_vec: Vec<i64> = vec![0i64; n_ipiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_mut_ptr();
+            #[cfg(feature = "ilp64")]
+            let jpiv_ilp64_vec_ptr = jpiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_jpiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut jpiv_ilp64_vec: Vec<i64> = vec![0i64; n_jpiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_ilp64_vec_ptr = jpiv_ilp64_vec.as_mut_ptr();
             let mut info_ilp64: i64 = *info as i64;
-            fun(&n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut jpiv_ilp64, &mut info_ilp64);
-            *ipiv = ipiv_ilp64 as lapackint;
-            *jpiv = jpiv_ilp64 as lapackint;
+            fun(&n_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, jpiv_ilp64_vec_ptr, &mut info_ilp64);
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_ipiv_ilp64 { *ipiv.add(i) = ipiv_ilp64_vec[i] as lapackint; }
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_jpiv_ilp64 { *jpiv.add(i) = jpiv_ilp64_vec[i] as lapackint; }
             *info = info_ilp64 as lapackint;
         }
     }
@@ -260,20 +336,36 @@ pub unsafe extern "C" fn cgetrf_(
             let m_lp64: i32 = *m as i32;
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let mut ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = std::cmp::min(m_lp64,n_lp64) as usize;
+            #[cfg(feature = "ilp64")]
+            let mut ipiv_lp64_vec: Vec<i32> = vec![0i32; n_ipiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_mut_ptr();
             let mut info_lp64: i32 = *info as i32;
-            fun(&m_lp64, &n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut info_lp64);
-            *ipiv = ipiv_lp64 as lapackint;
+            fun(&m_lp64, &n_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, &mut info_lp64);
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_ipiv_lp64 { *ipiv.add(i) = ipiv_lp64_vec[i] as lapackint; }
             *info = info_lp64 as lapackint;
         }
         CgetrfProvider::Ilp64(fun) => {
             let m_ilp64: i64 = *m as i64;
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = std::cmp::min(m_ilp64,n_ilp64) as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut ipiv_ilp64_vec: Vec<i64> = vec![0i64; n_ipiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_mut_ptr();
             let mut info_ilp64: i64 = *info as i64;
-            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut info_ilp64);
-            *ipiv = ipiv_ilp64 as lapackint;
+            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, &mut info_ilp64);
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_ipiv_ilp64 { *ipiv.add(i) = ipiv_ilp64_vec[i] as lapackint; }
             *info = info_ilp64 as lapackint;
         }
     }
@@ -297,19 +389,33 @@ pub unsafe extern "C" fn cgetri_(
         CgetriProvider::Lp64(fun) => {
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec: Vec<i32> = (0..n_ipiv_lp64).map(|i| *ipiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_ptr();
             let lwork_lp64: i32 = *lwork as i32;
             let mut info_lp64: i32 = *info as i32;
-            fun(&n_lp64, A, &lda_lp64, &ipiv_lp64, work, &lwork_lp64, &mut info_lp64);
+            fun(&n_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, work, &lwork_lp64, &mut info_lp64);
             *info = info_lp64 as lapackint;
         }
         CgetriProvider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec: Vec<i64> = (0..n_ipiv_ilp64).map(|i| *ipiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_ptr();
             let lwork_ilp64: i64 = *lwork as i64;
             let mut info_ilp64: i64 = *info as i64;
-            fun(&n_ilp64, A, &lda_ilp64, &ipiv_ilp64, work, &lwork_ilp64, &mut info_ilp64);
+            fun(&n_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, work, &lwork_ilp64, &mut info_ilp64);
             *info = info_ilp64 as lapackint;
         }
     }
@@ -336,20 +442,34 @@ pub unsafe extern "C" fn cgetrs_(
             let n_lp64: i32 = *n as i32;
             let nrhs_lp64: i32 = *nrhs as i32;
             let lda_lp64: i32 = *lda as i32;
-            let ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec: Vec<i32> = (0..n_ipiv_lp64).map(|i| *ipiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_ptr();
             let ldb_lp64: i32 = *ldb as i32;
             let mut info_lp64: i32 = *info as i32;
-            fun(trans, &n_lp64, &nrhs_lp64, A, &lda_lp64, &ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
+            fun(trans, &n_lp64, &nrhs_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, B, &ldb_lp64, &mut info_lp64);
             *info = info_lp64 as lapackint;
         }
         CgetrsProvider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let nrhs_ilp64: i64 = *nrhs as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec: Vec<i64> = (0..n_ipiv_ilp64).map(|i| *ipiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_ptr();
             let ldb_ilp64: i64 = *ldb as i64;
             let mut info_ilp64: i64 = *info as i64;
-            fun(trans, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            fun(trans, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, B, &ldb_ilp64, &mut info_ilp64);
             *info = info_ilp64 as lapackint;
         }
     }
@@ -601,16 +721,44 @@ pub unsafe extern "C" fn dgesc2_(
         Dgesc2Provider::Lp64(fun) => {
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let ipiv_lp64: i32 = *ipiv as i32;
-            let jpiv_lp64: i32 = *jpiv as i32;
-            fun(&n_lp64, A, &lda_lp64, rhs, &ipiv_lp64, &jpiv_lp64, scale)
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec: Vec<i32> = (0..n_ipiv_lp64).map(|i| *ipiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_ptr();
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_lp64_vec_ptr = jpiv;
+            #[cfg(feature = "ilp64")]
+            let n_jpiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let jpiv_lp64_vec: Vec<i32> = (0..n_jpiv_lp64).map(|i| *jpiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let jpiv_lp64_vec_ptr = jpiv_lp64_vec.as_ptr();
+            fun(&n_lp64, A, &lda_lp64, rhs, ipiv_lp64_vec_ptr, jpiv_lp64_vec_ptr, scale)
         }
         Dgesc2Provider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let ipiv_ilp64: i64 = *ipiv as i64;
-            let jpiv_ilp64: i64 = *jpiv as i64;
-            fun(&n_ilp64, A, &lda_ilp64, rhs, &ipiv_ilp64, &jpiv_ilp64, scale)
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec: Vec<i64> = (0..n_ipiv_ilp64).map(|i| *ipiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_ptr();
+            #[cfg(feature = "ilp64")]
+            let jpiv_ilp64_vec_ptr = jpiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_jpiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_ilp64_vec: Vec<i64> = (0..n_jpiv_ilp64).map(|i| *jpiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_ilp64_vec_ptr = jpiv_ilp64_vec.as_ptr();
+            fun(&n_ilp64, A, &lda_ilp64, rhs, ipiv_ilp64_vec_ptr, jpiv_ilp64_vec_ptr, scale)
         }
     }
 }
@@ -635,22 +783,38 @@ pub unsafe extern "C" fn dgesv_(
             let n_lp64: i32 = *n as i32;
             let nrhs_lp64: i32 = *nrhs as i32;
             let lda_lp64: i32 = *lda as i32;
-            let mut ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let mut ipiv_lp64_vec: Vec<i32> = vec![0i32; n_ipiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_mut_ptr();
             let ldb_lp64: i32 = *ldb as i32;
             let mut info_lp64: i32 = *info as i32;
-            fun(&n_lp64, &nrhs_lp64, A, &lda_lp64, &mut ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
-            *ipiv = ipiv_lp64 as lapackint;
+            fun(&n_lp64, &nrhs_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, B, &ldb_lp64, &mut info_lp64);
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_ipiv_lp64 { *ipiv.add(i) = ipiv_lp64_vec[i] as lapackint; }
             *info = info_lp64 as lapackint;
         }
         DgesvProvider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let nrhs_ilp64: i64 = *nrhs as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut ipiv_ilp64_vec: Vec<i64> = vec![0i64; n_ipiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_mut_ptr();
             let ldb_ilp64: i64 = *ldb as i64;
             let mut info_ilp64: i64 = *info as i64;
-            fun(&n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
-            *ipiv = ipiv_ilp64 as lapackint;
+            fun(&n_ilp64, &nrhs_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, B, &ldb_ilp64, &mut info_ilp64);
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_ipiv_ilp64 { *ipiv.add(i) = ipiv_ilp64_vec[i] as lapackint; }
             *info = info_ilp64 as lapackint;
         }
     }
@@ -720,23 +884,55 @@ pub unsafe extern "C" fn dgetc2_(
         Dgetc2Provider::Lp64(fun) => {
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let mut ipiv_lp64: i32 = *ipiv as i32;
-            let mut jpiv_lp64: i32 = *jpiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let mut ipiv_lp64_vec: Vec<i32> = vec![0i32; n_ipiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_mut_ptr();
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_lp64_vec_ptr = jpiv;
+            #[cfg(feature = "ilp64")]
+            let n_jpiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let mut jpiv_lp64_vec: Vec<i32> = vec![0i32; n_jpiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let jpiv_lp64_vec_ptr = jpiv_lp64_vec.as_mut_ptr();
             let mut info_lp64: i32 = *info as i32;
-            fun(&n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut jpiv_lp64, &mut info_lp64);
-            *ipiv = ipiv_lp64 as lapackint;
-            *jpiv = jpiv_lp64 as lapackint;
+            fun(&n_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, jpiv_lp64_vec_ptr, &mut info_lp64);
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_ipiv_lp64 { *ipiv.add(i) = ipiv_lp64_vec[i] as lapackint; }
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_jpiv_lp64 { *jpiv.add(i) = jpiv_lp64_vec[i] as lapackint; }
             *info = info_lp64 as lapackint;
         }
         Dgetc2Provider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let mut ipiv_ilp64: i64 = *ipiv as i64;
-            let mut jpiv_ilp64: i64 = *jpiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut ipiv_ilp64_vec: Vec<i64> = vec![0i64; n_ipiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_mut_ptr();
+            #[cfg(feature = "ilp64")]
+            let jpiv_ilp64_vec_ptr = jpiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_jpiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut jpiv_ilp64_vec: Vec<i64> = vec![0i64; n_jpiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_ilp64_vec_ptr = jpiv_ilp64_vec.as_mut_ptr();
             let mut info_ilp64: i64 = *info as i64;
-            fun(&n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut jpiv_ilp64, &mut info_ilp64);
-            *ipiv = ipiv_ilp64 as lapackint;
-            *jpiv = jpiv_ilp64 as lapackint;
+            fun(&n_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, jpiv_ilp64_vec_ptr, &mut info_ilp64);
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_ipiv_ilp64 { *ipiv.add(i) = ipiv_ilp64_vec[i] as lapackint; }
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_jpiv_ilp64 { *jpiv.add(i) = jpiv_ilp64_vec[i] as lapackint; }
             *info = info_ilp64 as lapackint;
         }
     }
@@ -760,20 +956,36 @@ pub unsafe extern "C" fn dgetrf_(
             let m_lp64: i32 = *m as i32;
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let mut ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = std::cmp::min(m_lp64,n_lp64) as usize;
+            #[cfg(feature = "ilp64")]
+            let mut ipiv_lp64_vec: Vec<i32> = vec![0i32; n_ipiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_mut_ptr();
             let mut info_lp64: i32 = *info as i32;
-            fun(&m_lp64, &n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut info_lp64);
-            *ipiv = ipiv_lp64 as lapackint;
+            fun(&m_lp64, &n_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, &mut info_lp64);
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_ipiv_lp64 { *ipiv.add(i) = ipiv_lp64_vec[i] as lapackint; }
             *info = info_lp64 as lapackint;
         }
         DgetrfProvider::Ilp64(fun) => {
             let m_ilp64: i64 = *m as i64;
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = std::cmp::min(m_ilp64,n_ilp64) as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut ipiv_ilp64_vec: Vec<i64> = vec![0i64; n_ipiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_mut_ptr();
             let mut info_ilp64: i64 = *info as i64;
-            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut info_ilp64);
-            *ipiv = ipiv_ilp64 as lapackint;
+            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, &mut info_ilp64);
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_ipiv_ilp64 { *ipiv.add(i) = ipiv_ilp64_vec[i] as lapackint; }
             *info = info_ilp64 as lapackint;
         }
     }
@@ -797,19 +1009,33 @@ pub unsafe extern "C" fn dgetri_(
         DgetriProvider::Lp64(fun) => {
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec: Vec<i32> = (0..n_ipiv_lp64).map(|i| *ipiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_ptr();
             let lwork_lp64: i32 = *lwork as i32;
             let mut info_lp64: i32 = *info as i32;
-            fun(&n_lp64, A, &lda_lp64, &ipiv_lp64, work, &lwork_lp64, &mut info_lp64);
+            fun(&n_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, work, &lwork_lp64, &mut info_lp64);
             *info = info_lp64 as lapackint;
         }
         DgetriProvider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec: Vec<i64> = (0..n_ipiv_ilp64).map(|i| *ipiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_ptr();
             let lwork_ilp64: i64 = *lwork as i64;
             let mut info_ilp64: i64 = *info as i64;
-            fun(&n_ilp64, A, &lda_ilp64, &ipiv_ilp64, work, &lwork_ilp64, &mut info_ilp64);
+            fun(&n_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, work, &lwork_ilp64, &mut info_ilp64);
             *info = info_ilp64 as lapackint;
         }
     }
@@ -836,20 +1062,34 @@ pub unsafe extern "C" fn dgetrs_(
             let n_lp64: i32 = *n as i32;
             let nrhs_lp64: i32 = *nrhs as i32;
             let lda_lp64: i32 = *lda as i32;
-            let ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec: Vec<i32> = (0..n_ipiv_lp64).map(|i| *ipiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_ptr();
             let ldb_lp64: i32 = *ldb as i32;
             let mut info_lp64: i32 = *info as i32;
-            fun(trans, &n_lp64, &nrhs_lp64, A, &lda_lp64, &ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
+            fun(trans, &n_lp64, &nrhs_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, B, &ldb_lp64, &mut info_lp64);
             *info = info_lp64 as lapackint;
         }
         DgetrsProvider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let nrhs_ilp64: i64 = *nrhs as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec: Vec<i64> = (0..n_ipiv_ilp64).map(|i| *ipiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_ptr();
             let ldb_ilp64: i64 = *ldb as i64;
             let mut info_ilp64: i64 = *info as i64;
-            fun(trans, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            fun(trans, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, B, &ldb_ilp64, &mut info_ilp64);
             *info = info_ilp64 as lapackint;
         }
     }
@@ -1100,16 +1340,44 @@ pub unsafe extern "C" fn sgesc2_(
         Sgesc2Provider::Lp64(fun) => {
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let ipiv_lp64: i32 = *ipiv as i32;
-            let jpiv_lp64: i32 = *jpiv as i32;
-            fun(&n_lp64, A, &lda_lp64, rhs, &ipiv_lp64, &jpiv_lp64, scale)
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec: Vec<i32> = (0..n_ipiv_lp64).map(|i| *ipiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_ptr();
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_lp64_vec_ptr = jpiv;
+            #[cfg(feature = "ilp64")]
+            let n_jpiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let jpiv_lp64_vec: Vec<i32> = (0..n_jpiv_lp64).map(|i| *jpiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let jpiv_lp64_vec_ptr = jpiv_lp64_vec.as_ptr();
+            fun(&n_lp64, A, &lda_lp64, rhs, ipiv_lp64_vec_ptr, jpiv_lp64_vec_ptr, scale)
         }
         Sgesc2Provider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let ipiv_ilp64: i64 = *ipiv as i64;
-            let jpiv_ilp64: i64 = *jpiv as i64;
-            fun(&n_ilp64, A, &lda_ilp64, rhs, &ipiv_ilp64, &jpiv_ilp64, scale)
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec: Vec<i64> = (0..n_ipiv_ilp64).map(|i| *ipiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_ptr();
+            #[cfg(feature = "ilp64")]
+            let jpiv_ilp64_vec_ptr = jpiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_jpiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_ilp64_vec: Vec<i64> = (0..n_jpiv_ilp64).map(|i| *jpiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_ilp64_vec_ptr = jpiv_ilp64_vec.as_ptr();
+            fun(&n_ilp64, A, &lda_ilp64, rhs, ipiv_ilp64_vec_ptr, jpiv_ilp64_vec_ptr, scale)
         }
     }
 }
@@ -1134,22 +1402,38 @@ pub unsafe extern "C" fn sgesv_(
             let n_lp64: i32 = *n as i32;
             let nrhs_lp64: i32 = *nrhs as i32;
             let lda_lp64: i32 = *lda as i32;
-            let mut ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let mut ipiv_lp64_vec: Vec<i32> = vec![0i32; n_ipiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_mut_ptr();
             let ldb_lp64: i32 = *ldb as i32;
             let mut info_lp64: i32 = *info as i32;
-            fun(&n_lp64, &nrhs_lp64, A, &lda_lp64, &mut ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
-            *ipiv = ipiv_lp64 as lapackint;
+            fun(&n_lp64, &nrhs_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, B, &ldb_lp64, &mut info_lp64);
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_ipiv_lp64 { *ipiv.add(i) = ipiv_lp64_vec[i] as lapackint; }
             *info = info_lp64 as lapackint;
         }
         SgesvProvider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let nrhs_ilp64: i64 = *nrhs as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut ipiv_ilp64_vec: Vec<i64> = vec![0i64; n_ipiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_mut_ptr();
             let ldb_ilp64: i64 = *ldb as i64;
             let mut info_ilp64: i64 = *info as i64;
-            fun(&n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
-            *ipiv = ipiv_ilp64 as lapackint;
+            fun(&n_ilp64, &nrhs_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, B, &ldb_ilp64, &mut info_ilp64);
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_ipiv_ilp64 { *ipiv.add(i) = ipiv_ilp64_vec[i] as lapackint; }
             *info = info_ilp64 as lapackint;
         }
     }
@@ -1219,23 +1503,55 @@ pub unsafe extern "C" fn sgetc2_(
         Sgetc2Provider::Lp64(fun) => {
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let mut ipiv_lp64: i32 = *ipiv as i32;
-            let mut jpiv_lp64: i32 = *jpiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let mut ipiv_lp64_vec: Vec<i32> = vec![0i32; n_ipiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_mut_ptr();
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_lp64_vec_ptr = jpiv;
+            #[cfg(feature = "ilp64")]
+            let n_jpiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let mut jpiv_lp64_vec: Vec<i32> = vec![0i32; n_jpiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let jpiv_lp64_vec_ptr = jpiv_lp64_vec.as_mut_ptr();
             let mut info_lp64: i32 = *info as i32;
-            fun(&n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut jpiv_lp64, &mut info_lp64);
-            *ipiv = ipiv_lp64 as lapackint;
-            *jpiv = jpiv_lp64 as lapackint;
+            fun(&n_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, jpiv_lp64_vec_ptr, &mut info_lp64);
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_ipiv_lp64 { *ipiv.add(i) = ipiv_lp64_vec[i] as lapackint; }
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_jpiv_lp64 { *jpiv.add(i) = jpiv_lp64_vec[i] as lapackint; }
             *info = info_lp64 as lapackint;
         }
         Sgetc2Provider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let mut ipiv_ilp64: i64 = *ipiv as i64;
-            let mut jpiv_ilp64: i64 = *jpiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut ipiv_ilp64_vec: Vec<i64> = vec![0i64; n_ipiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_mut_ptr();
+            #[cfg(feature = "ilp64")]
+            let jpiv_ilp64_vec_ptr = jpiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_jpiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut jpiv_ilp64_vec: Vec<i64> = vec![0i64; n_jpiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_ilp64_vec_ptr = jpiv_ilp64_vec.as_mut_ptr();
             let mut info_ilp64: i64 = *info as i64;
-            fun(&n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut jpiv_ilp64, &mut info_ilp64);
-            *ipiv = ipiv_ilp64 as lapackint;
-            *jpiv = jpiv_ilp64 as lapackint;
+            fun(&n_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, jpiv_ilp64_vec_ptr, &mut info_ilp64);
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_ipiv_ilp64 { *ipiv.add(i) = ipiv_ilp64_vec[i] as lapackint; }
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_jpiv_ilp64 { *jpiv.add(i) = jpiv_ilp64_vec[i] as lapackint; }
             *info = info_ilp64 as lapackint;
         }
     }
@@ -1259,20 +1575,36 @@ pub unsafe extern "C" fn sgetrf_(
             let m_lp64: i32 = *m as i32;
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let mut ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = std::cmp::min(m_lp64,n_lp64) as usize;
+            #[cfg(feature = "ilp64")]
+            let mut ipiv_lp64_vec: Vec<i32> = vec![0i32; n_ipiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_mut_ptr();
             let mut info_lp64: i32 = *info as i32;
-            fun(&m_lp64, &n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut info_lp64);
-            *ipiv = ipiv_lp64 as lapackint;
+            fun(&m_lp64, &n_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, &mut info_lp64);
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_ipiv_lp64 { *ipiv.add(i) = ipiv_lp64_vec[i] as lapackint; }
             *info = info_lp64 as lapackint;
         }
         SgetrfProvider::Ilp64(fun) => {
             let m_ilp64: i64 = *m as i64;
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = std::cmp::min(m_ilp64,n_ilp64) as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut ipiv_ilp64_vec: Vec<i64> = vec![0i64; n_ipiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_mut_ptr();
             let mut info_ilp64: i64 = *info as i64;
-            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut info_ilp64);
-            *ipiv = ipiv_ilp64 as lapackint;
+            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, &mut info_ilp64);
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_ipiv_ilp64 { *ipiv.add(i) = ipiv_ilp64_vec[i] as lapackint; }
             *info = info_ilp64 as lapackint;
         }
     }
@@ -1296,19 +1628,33 @@ pub unsafe extern "C" fn sgetri_(
         SgetriProvider::Lp64(fun) => {
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec: Vec<i32> = (0..n_ipiv_lp64).map(|i| *ipiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_ptr();
             let lwork_lp64: i32 = *lwork as i32;
             let mut info_lp64: i32 = *info as i32;
-            fun(&n_lp64, A, &lda_lp64, &ipiv_lp64, work, &lwork_lp64, &mut info_lp64);
+            fun(&n_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, work, &lwork_lp64, &mut info_lp64);
             *info = info_lp64 as lapackint;
         }
         SgetriProvider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec: Vec<i64> = (0..n_ipiv_ilp64).map(|i| *ipiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_ptr();
             let lwork_ilp64: i64 = *lwork as i64;
             let mut info_ilp64: i64 = *info as i64;
-            fun(&n_ilp64, A, &lda_ilp64, &ipiv_ilp64, work, &lwork_ilp64, &mut info_ilp64);
+            fun(&n_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, work, &lwork_ilp64, &mut info_ilp64);
             *info = info_ilp64 as lapackint;
         }
     }
@@ -1335,20 +1681,34 @@ pub unsafe extern "C" fn sgetrs_(
             let n_lp64: i32 = *n as i32;
             let nrhs_lp64: i32 = *nrhs as i32;
             let lda_lp64: i32 = *lda as i32;
-            let ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec: Vec<i32> = (0..n_ipiv_lp64).map(|i| *ipiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_ptr();
             let ldb_lp64: i32 = *ldb as i32;
             let mut info_lp64: i32 = *info as i32;
-            fun(trans, &n_lp64, &nrhs_lp64, A, &lda_lp64, &ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
+            fun(trans, &n_lp64, &nrhs_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, B, &ldb_lp64, &mut info_lp64);
             *info = info_lp64 as lapackint;
         }
         SgetrsProvider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let nrhs_ilp64: i64 = *nrhs as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec: Vec<i64> = (0..n_ipiv_ilp64).map(|i| *ipiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_ptr();
             let ldb_ilp64: i64 = *ldb as i64;
             let mut info_ilp64: i64 = *info as i64;
-            fun(trans, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            fun(trans, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, B, &ldb_ilp64, &mut info_ilp64);
             *info = info_ilp64 as lapackint;
         }
     }
@@ -1599,16 +1959,44 @@ pub unsafe extern "C" fn zgesc2_(
         Zgesc2Provider::Lp64(fun) => {
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let ipiv_lp64: i32 = *ipiv as i32;
-            let jpiv_lp64: i32 = *jpiv as i32;
-            fun(&n_lp64, A, &lda_lp64, rhs, &ipiv_lp64, &jpiv_lp64, scale)
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec: Vec<i32> = (0..n_ipiv_lp64).map(|i| *ipiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_ptr();
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_lp64_vec_ptr = jpiv;
+            #[cfg(feature = "ilp64")]
+            let n_jpiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let jpiv_lp64_vec: Vec<i32> = (0..n_jpiv_lp64).map(|i| *jpiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let jpiv_lp64_vec_ptr = jpiv_lp64_vec.as_ptr();
+            fun(&n_lp64, A, &lda_lp64, rhs, ipiv_lp64_vec_ptr, jpiv_lp64_vec_ptr, scale)
         }
         Zgesc2Provider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let ipiv_ilp64: i64 = *ipiv as i64;
-            let jpiv_ilp64: i64 = *jpiv as i64;
-            fun(&n_ilp64, A, &lda_ilp64, rhs, &ipiv_ilp64, &jpiv_ilp64, scale)
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec: Vec<i64> = (0..n_ipiv_ilp64).map(|i| *ipiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_ptr();
+            #[cfg(feature = "ilp64")]
+            let jpiv_ilp64_vec_ptr = jpiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_jpiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_ilp64_vec: Vec<i64> = (0..n_jpiv_ilp64).map(|i| *jpiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_ilp64_vec_ptr = jpiv_ilp64_vec.as_ptr();
+            fun(&n_ilp64, A, &lda_ilp64, rhs, ipiv_ilp64_vec_ptr, jpiv_ilp64_vec_ptr, scale)
         }
     }
 }
@@ -1633,22 +2021,38 @@ pub unsafe extern "C" fn zgesv_(
             let n_lp64: i32 = *n as i32;
             let nrhs_lp64: i32 = *nrhs as i32;
             let lda_lp64: i32 = *lda as i32;
-            let mut ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let mut ipiv_lp64_vec: Vec<i32> = vec![0i32; n_ipiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_mut_ptr();
             let ldb_lp64: i32 = *ldb as i32;
             let mut info_lp64: i32 = *info as i32;
-            fun(&n_lp64, &nrhs_lp64, A, &lda_lp64, &mut ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
-            *ipiv = ipiv_lp64 as lapackint;
+            fun(&n_lp64, &nrhs_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, B, &ldb_lp64, &mut info_lp64);
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_ipiv_lp64 { *ipiv.add(i) = ipiv_lp64_vec[i] as lapackint; }
             *info = info_lp64 as lapackint;
         }
         ZgesvProvider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let nrhs_ilp64: i64 = *nrhs as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut ipiv_ilp64_vec: Vec<i64> = vec![0i64; n_ipiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_mut_ptr();
             let ldb_ilp64: i64 = *ldb as i64;
             let mut info_ilp64: i64 = *info as i64;
-            fun(&n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
-            *ipiv = ipiv_ilp64 as lapackint;
+            fun(&n_ilp64, &nrhs_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, B, &ldb_ilp64, &mut info_ilp64);
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_ipiv_ilp64 { *ipiv.add(i) = ipiv_ilp64_vec[i] as lapackint; }
             *info = info_ilp64 as lapackint;
         }
     }
@@ -1719,23 +2123,55 @@ pub unsafe extern "C" fn zgetc2_(
         Zgetc2Provider::Lp64(fun) => {
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let mut ipiv_lp64: i32 = *ipiv as i32;
-            let mut jpiv_lp64: i32 = *jpiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let mut ipiv_lp64_vec: Vec<i32> = vec![0i32; n_ipiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_mut_ptr();
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_lp64_vec_ptr = jpiv;
+            #[cfg(feature = "ilp64")]
+            let n_jpiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let mut jpiv_lp64_vec: Vec<i32> = vec![0i32; n_jpiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let jpiv_lp64_vec_ptr = jpiv_lp64_vec.as_mut_ptr();
             let mut info_lp64: i32 = *info as i32;
-            fun(&n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut jpiv_lp64, &mut info_lp64);
-            *ipiv = ipiv_lp64 as lapackint;
-            *jpiv = jpiv_lp64 as lapackint;
+            fun(&n_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, jpiv_lp64_vec_ptr, &mut info_lp64);
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_ipiv_lp64 { *ipiv.add(i) = ipiv_lp64_vec[i] as lapackint; }
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_jpiv_lp64 { *jpiv.add(i) = jpiv_lp64_vec[i] as lapackint; }
             *info = info_lp64 as lapackint;
         }
         Zgetc2Provider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let mut ipiv_ilp64: i64 = *ipiv as i64;
-            let mut jpiv_ilp64: i64 = *jpiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut ipiv_ilp64_vec: Vec<i64> = vec![0i64; n_ipiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_mut_ptr();
+            #[cfg(feature = "ilp64")]
+            let jpiv_ilp64_vec_ptr = jpiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_jpiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut jpiv_ilp64_vec: Vec<i64> = vec![0i64; n_jpiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let jpiv_ilp64_vec_ptr = jpiv_ilp64_vec.as_mut_ptr();
             let mut info_ilp64: i64 = *info as i64;
-            fun(&n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut jpiv_ilp64, &mut info_ilp64);
-            *ipiv = ipiv_ilp64 as lapackint;
-            *jpiv = jpiv_ilp64 as lapackint;
+            fun(&n_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, jpiv_ilp64_vec_ptr, &mut info_ilp64);
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_ipiv_ilp64 { *ipiv.add(i) = ipiv_ilp64_vec[i] as lapackint; }
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_jpiv_ilp64 { *jpiv.add(i) = jpiv_ilp64_vec[i] as lapackint; }
             *info = info_ilp64 as lapackint;
         }
     }
@@ -1759,20 +2195,36 @@ pub unsafe extern "C" fn zgetrf_(
             let m_lp64: i32 = *m as i32;
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let mut ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = std::cmp::min(m_lp64,n_lp64) as usize;
+            #[cfg(feature = "ilp64")]
+            let mut ipiv_lp64_vec: Vec<i32> = vec![0i32; n_ipiv_lp64];
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_mut_ptr();
             let mut info_lp64: i32 = *info as i32;
-            fun(&m_lp64, &n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut info_lp64);
-            *ipiv = ipiv_lp64 as lapackint;
+            fun(&m_lp64, &n_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, &mut info_lp64);
+            #[cfg(feature = "ilp64")]
+            for i in 0..n_ipiv_lp64 { *ipiv.add(i) = ipiv_lp64_vec[i] as lapackint; }
             *info = info_lp64 as lapackint;
         }
         ZgetrfProvider::Ilp64(fun) => {
             let m_ilp64: i64 = *m as i64;
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = std::cmp::min(m_ilp64,n_ilp64) as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let mut ipiv_ilp64_vec: Vec<i64> = vec![0i64; n_ipiv_ilp64];
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_mut_ptr();
             let mut info_ilp64: i64 = *info as i64;
-            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut info_ilp64);
-            *ipiv = ipiv_ilp64 as lapackint;
+            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, &mut info_ilp64);
+            #[cfg(not(feature = "ilp64"))]
+            for i in 0..n_ipiv_ilp64 { *ipiv.add(i) = ipiv_ilp64_vec[i] as lapackint; }
             *info = info_ilp64 as lapackint;
         }
     }
@@ -1796,19 +2248,33 @@ pub unsafe extern "C" fn zgetri_(
         ZgetriProvider::Lp64(fun) => {
             let n_lp64: i32 = *n as i32;
             let lda_lp64: i32 = *lda as i32;
-            let ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec: Vec<i32> = (0..n_ipiv_lp64).map(|i| *ipiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_ptr();
             let lwork_lp64: i32 = *lwork as i32;
             let mut info_lp64: i32 = *info as i32;
-            fun(&n_lp64, A, &lda_lp64, &ipiv_lp64, work, &lwork_lp64, &mut info_lp64);
+            fun(&n_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, work, &lwork_lp64, &mut info_lp64);
             *info = info_lp64 as lapackint;
         }
         ZgetriProvider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec: Vec<i64> = (0..n_ipiv_ilp64).map(|i| *ipiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_ptr();
             let lwork_ilp64: i64 = *lwork as i64;
             let mut info_ilp64: i64 = *info as i64;
-            fun(&n_ilp64, A, &lda_ilp64, &ipiv_ilp64, work, &lwork_ilp64, &mut info_ilp64);
+            fun(&n_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, work, &lwork_ilp64, &mut info_ilp64);
             *info = info_ilp64 as lapackint;
         }
     }
@@ -1835,20 +2301,34 @@ pub unsafe extern "C" fn zgetrs_(
             let n_lp64: i32 = *n as i32;
             let nrhs_lp64: i32 = *nrhs as i32;
             let lda_lp64: i32 = *lda as i32;
-            let ipiv_lp64: i32 = *ipiv as i32;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_lp64_vec_ptr = ipiv;
+            #[cfg(feature = "ilp64")]
+            let n_ipiv_lp64 = n_lp64 as usize;
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec: Vec<i32> = (0..n_ipiv_lp64).map(|i| *ipiv.add(i) as i32).collect();
+            #[cfg(feature = "ilp64")]
+            let ipiv_lp64_vec_ptr = ipiv_lp64_vec.as_ptr();
             let ldb_lp64: i32 = *ldb as i32;
             let mut info_lp64: i32 = *info as i32;
-            fun(trans, &n_lp64, &nrhs_lp64, A, &lda_lp64, &ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
+            fun(trans, &n_lp64, &nrhs_lp64, A, &lda_lp64, ipiv_lp64_vec_ptr, B, &ldb_lp64, &mut info_lp64);
             *info = info_lp64 as lapackint;
         }
         ZgetrsProvider::Ilp64(fun) => {
             let n_ilp64: i64 = *n as i64;
             let nrhs_ilp64: i64 = *nrhs as i64;
             let lda_ilp64: i64 = *lda as i64;
-            let ipiv_ilp64: i64 = *ipiv as i64;
+            #[cfg(feature = "ilp64")]
+            let ipiv_ilp64_vec_ptr = ipiv;
+            #[cfg(not(feature = "ilp64"))]
+            let n_ipiv_ilp64 = n_ilp64 as usize;
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec: Vec<i64> = (0..n_ipiv_ilp64).map(|i| *ipiv.add(i) as i64).collect();
+            #[cfg(not(feature = "ilp64"))]
+            let ipiv_ilp64_vec_ptr = ipiv_ilp64_vec.as_ptr();
             let ldb_ilp64: i64 = *ldb as i64;
             let mut info_ilp64: i64 = *info as i64;
-            fun(trans, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            fun(trans, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, ipiv_ilp64_vec_ptr, B, &ldb_ilp64, &mut info_ilp64);
             *info = info_ilp64 as lapackint;
         }
     }

--- a/src/fortran_gen.rs
+++ b/src/fortran_gen.rs
@@ -23,22 +23,24 @@ pub unsafe extern "C" fn cgeev_(
     let provider = get_cgeev_for_lp64();
     match provider {
         CgeevProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ldvl_lp64: *const i32 = ldvl as *const i32;
-            let ldvr_lp64: *const i32 = ldvr as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(jobvl, jobvr, n_lp64, A, lda_lp64, W, VL, ldvl_lp64, VR, ldvr_lp64, work, lwork_lp64, rwork, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ldvl_lp64: i32 = *ldvl as i32;
+            let ldvr_lp64: i32 = *ldvr as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(jobvl, jobvr, &n_lp64, A, &lda_lp64, W, VL, &ldvl_lp64, VR, &ldvr_lp64, work, &lwork_lp64, rwork, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         CgeevProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ldvl_ilp64: *const i64 = ldvl as *const i64;
-            let ldvr_ilp64: *const i64 = ldvr as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(jobvl, jobvr, n_ilp64, A, lda_ilp64, W, VL, ldvl_ilp64, VR, ldvr_ilp64, work, lwork_ilp64, rwork, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ldvl_ilp64: i64 = *ldvl as i64;
+            let ldvr_ilp64: i64 = *ldvr as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(jobvl, jobvr, &n_ilp64, A, &lda_ilp64, W, VL, &ldvl_ilp64, VR, &ldvr_ilp64, work, &lwork_ilp64, rwork, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -60,20 +62,22 @@ pub unsafe extern "C" fn cgeqrf_(
     let provider = get_cgeqrf_for_lp64();
     match provider {
         CgeqrfProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(m_lp64, n_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&m_lp64, &n_lp64, A, &lda_lp64, tau, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         CgeqrfProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(m_ilp64, n_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, tau, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -94,18 +98,18 @@ pub unsafe extern "C" fn cgesc2_(
     let provider = get_cgesc2_for_lp64();
     match provider {
         Cgesc2Provider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *const i32 = ipiv as *const i32;
-            let jpiv_lp64: *const i32 = jpiv as *const i32;
-            fun(n_lp64, A, lda_lp64, rhs, ipiv_lp64, jpiv_lp64, scale)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ipiv_lp64: i32 = *ipiv as i32;
+            let jpiv_lp64: i32 = *jpiv as i32;
+            fun(&n_lp64, A, &lda_lp64, rhs, &ipiv_lp64, &jpiv_lp64, scale)
         }
         Cgesc2Provider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *const i64 = ipiv as *const i64;
-            let jpiv_ilp64: *const i64 = jpiv as *const i64;
-            fun(n_ilp64, A, lda_ilp64, rhs, ipiv_ilp64, jpiv_ilp64, scale)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ipiv_ilp64: i64 = *ipiv as i64;
+            let jpiv_ilp64: i64 = *jpiv as i64;
+            fun(&n_ilp64, A, &lda_ilp64, rhs, &ipiv_ilp64, &jpiv_ilp64, scale)
         }
     }
 }
@@ -127,22 +131,26 @@ pub unsafe extern "C" fn cgesv_(
     let provider = get_cgesv_for_lp64();
     match provider {
         CgesvProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let nrhs_lp64: *const i32 = nrhs as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *mut i32 = ipiv as *mut i32;
-            let ldb_lp64: *const i32 = ldb as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(n_lp64, nrhs_lp64, A, lda_lp64, ipiv_lp64, B, ldb_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let nrhs_lp64: i32 = *nrhs as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut ipiv_lp64: i32 = *ipiv as i32;
+            let ldb_lp64: i32 = *ldb as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&n_lp64, &nrhs_lp64, A, &lda_lp64, &mut ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
+            *ipiv = ipiv_lp64 as lapackint;
+            *info = info_lp64 as lapackint;
         }
         CgesvProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let nrhs_ilp64: *const i64 = nrhs as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *mut i64 = ipiv as *mut i64;
-            let ldb_ilp64: *const i64 = ldb as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(n_ilp64, nrhs_ilp64, A, lda_ilp64, ipiv_ilp64, B, ldb_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let nrhs_ilp64: i64 = *nrhs as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            let ldb_ilp64: i64 = *ldb as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            *ipiv = ipiv_ilp64 as lapackint;
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -171,24 +179,26 @@ pub unsafe extern "C" fn cgesvd_(
     let provider = get_cgesvd_for_lp64();
     match provider {
         CgesvdProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ldu_lp64: *const i32 = ldu as *const i32;
-            let ldvt_lp64: *const i32 = ldvt as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(jobu, jobvt, m_lp64, n_lp64, A, lda_lp64, S, U, ldu_lp64, VT, ldvt_lp64, work, lwork_lp64, rwork, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ldu_lp64: i32 = *ldu as i32;
+            let ldvt_lp64: i32 = *ldvt as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(jobu, jobvt, &m_lp64, &n_lp64, A, &lda_lp64, S, U, &ldu_lp64, VT, &ldvt_lp64, work, &lwork_lp64, rwork, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         CgesvdProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ldu_ilp64: *const i64 = ldu as *const i64;
-            let ldvt_ilp64: *const i64 = ldvt as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(jobu, jobvt, m_ilp64, n_ilp64, A, lda_ilp64, S, U, ldu_ilp64, VT, ldvt_ilp64, work, lwork_ilp64, rwork, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ldu_ilp64: i64 = *ldu as i64;
+            let ldvt_ilp64: i64 = *ldvt as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(jobu, jobvt, &m_ilp64, &n_ilp64, A, &lda_ilp64, S, U, &ldu_ilp64, VT, &ldvt_ilp64, work, &lwork_ilp64, rwork, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -208,20 +218,26 @@ pub unsafe extern "C" fn cgetc2_(
     let provider = get_cgetc2_for_lp64();
     match provider {
         Cgetc2Provider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *mut i32 = ipiv as *mut i32;
-            let jpiv_lp64: *mut i32 = jpiv as *mut i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(n_lp64, A, lda_lp64, ipiv_lp64, jpiv_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut ipiv_lp64: i32 = *ipiv as i32;
+            let mut jpiv_lp64: i32 = *jpiv as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut jpiv_lp64, &mut info_lp64);
+            *ipiv = ipiv_lp64 as lapackint;
+            *jpiv = jpiv_lp64 as lapackint;
+            *info = info_lp64 as lapackint;
         }
         Cgetc2Provider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *mut i64 = ipiv as *mut i64;
-            let jpiv_ilp64: *mut i64 = jpiv as *mut i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(n_ilp64, A, lda_ilp64, ipiv_ilp64, jpiv_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            let mut jpiv_ilp64: i64 = *jpiv as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut jpiv_ilp64, &mut info_ilp64);
+            *ipiv = ipiv_ilp64 as lapackint;
+            *jpiv = jpiv_ilp64 as lapackint;
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -241,20 +257,24 @@ pub unsafe extern "C" fn cgetrf_(
     let provider = get_cgetrf_for_lp64();
     match provider {
         CgetrfProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *mut i32 = ipiv as *mut i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(m_lp64, n_lp64, A, lda_lp64, ipiv_lp64, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut ipiv_lp64: i32 = *ipiv as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&m_lp64, &n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut info_lp64);
+            *ipiv = ipiv_lp64 as lapackint;
+            *info = info_lp64 as lapackint;
         }
         CgetrfProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *mut i64 = ipiv as *mut i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(m_ilp64, n_ilp64, A, lda_ilp64, ipiv_ilp64, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut info_ilp64);
+            *ipiv = ipiv_ilp64 as lapackint;
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -275,20 +295,22 @@ pub unsafe extern "C" fn cgetri_(
     let provider = get_cgetri_for_lp64();
     match provider {
         CgetriProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *const i32 = ipiv as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(n_lp64, A, lda_lp64, ipiv_lp64, work, lwork_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ipiv_lp64: i32 = *ipiv as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&n_lp64, A, &lda_lp64, &ipiv_lp64, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         CgetriProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *const i64 = ipiv as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(n_ilp64, A, lda_ilp64, ipiv_ilp64, work, lwork_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ipiv_ilp64: i64 = *ipiv as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&n_ilp64, A, &lda_ilp64, &ipiv_ilp64, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -311,22 +333,24 @@ pub unsafe extern "C" fn cgetrs_(
     let provider = get_cgetrs_for_lp64();
     match provider {
         CgetrsProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let nrhs_lp64: *const i32 = nrhs as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *const i32 = ipiv as *const i32;
-            let ldb_lp64: *const i32 = ldb as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(trans, n_lp64, nrhs_lp64, A, lda_lp64, ipiv_lp64, B, ldb_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let nrhs_lp64: i32 = *nrhs as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ipiv_lp64: i32 = *ipiv as i32;
+            let ldb_lp64: i32 = *ldb as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(trans, &n_lp64, &nrhs_lp64, A, &lda_lp64, &ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         CgetrsProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let nrhs_ilp64: *const i64 = nrhs as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *const i64 = ipiv as *const i64;
-            let ldb_ilp64: *const i64 = ldb as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(trans, n_ilp64, nrhs_ilp64, A, lda_ilp64, ipiv_ilp64, B, ldb_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let nrhs_ilp64: i64 = *nrhs as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ipiv_ilp64: i64 = *ipiv as i64;
+            let ldb_ilp64: i64 = *ldb as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(trans, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -350,18 +374,20 @@ pub unsafe extern "C" fn cheev_(
     let provider = get_cheev_for_lp64();
     match provider {
         CheevProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(jobz, uplo, n_lp64, A, lda_lp64, W, work, lwork_lp64, rwork, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(jobz, uplo, &n_lp64, A, &lda_lp64, W, work, &lwork_lp64, rwork, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         CheevProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(jobz, uplo, n_ilp64, A, lda_ilp64, W, work, lwork_ilp64, rwork, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(jobz, uplo, &n_ilp64, A, &lda_ilp64, W, work, &lwork_ilp64, rwork, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -380,16 +406,18 @@ pub unsafe extern "C" fn cpotrf_(
     let provider = get_cpotrf_for_lp64();
     match provider {
         CpotrfProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(uplo, n_lp64, A, lda_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(uplo, &n_lp64, A, &lda_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         CpotrfProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(uplo, n_ilp64, A, lda_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(uplo, &n_ilp64, A, &lda_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -413,20 +441,22 @@ pub unsafe extern "C" fn ctrtrs_(
     let provider = get_ctrtrs_for_lp64();
     match provider {
         CtrtrsProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let nrhs_lp64: *const i32 = nrhs as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ldb_lp64: *const i32 = ldb as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(uplo, trans, diag, n_lp64, nrhs_lp64, A, lda_lp64, B, ldb_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let nrhs_lp64: i32 = *nrhs as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ldb_lp64: i32 = *ldb as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(uplo, trans, diag, &n_lp64, &nrhs_lp64, A, &lda_lp64, B, &ldb_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         CtrtrsProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let nrhs_ilp64: *const i64 = nrhs as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ldb_ilp64: *const i64 = ldb as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(uplo, trans, diag, n_ilp64, nrhs_ilp64, A, lda_ilp64, B, ldb_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let nrhs_ilp64: i64 = *nrhs as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ldb_ilp64: i64 = *ldb as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(uplo, trans, diag, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -449,22 +479,24 @@ pub unsafe extern "C" fn cungqr_(
     let provider = get_cungqr_for_lp64();
     match provider {
         CungqrProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let k_lp64: *const i32 = k as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(m_lp64, n_lp64, k_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let k_lp64: i32 = *k as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&m_lp64, &n_lp64, &k_lp64, A, &lda_lp64, tau, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         CungqrProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let k_ilp64: *const i64 = k as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(m_ilp64, n_ilp64, k_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let k_ilp64: i64 = *k as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&m_ilp64, &n_ilp64, &k_ilp64, A, &lda_ilp64, tau, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -492,22 +524,24 @@ pub unsafe extern "C" fn dgeev_(
     let provider = get_dgeev_for_lp64();
     match provider {
         DgeevProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ldvl_lp64: *const i32 = ldvl as *const i32;
-            let ldvr_lp64: *const i32 = ldvr as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(jobvl, jobvr, n_lp64, A, lda_lp64, WR, WI, VL, ldvl_lp64, VR, ldvr_lp64, work, lwork_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ldvl_lp64: i32 = *ldvl as i32;
+            let ldvr_lp64: i32 = *ldvr as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(jobvl, jobvr, &n_lp64, A, &lda_lp64, WR, WI, VL, &ldvl_lp64, VR, &ldvr_lp64, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         DgeevProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ldvl_ilp64: *const i64 = ldvl as *const i64;
-            let ldvr_ilp64: *const i64 = ldvr as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(jobvl, jobvr, n_ilp64, A, lda_ilp64, WR, WI, VL, ldvl_ilp64, VR, ldvr_ilp64, work, lwork_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ldvl_ilp64: i64 = *ldvl as i64;
+            let ldvr_ilp64: i64 = *ldvr as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(jobvl, jobvr, &n_ilp64, A, &lda_ilp64, WR, WI, VL, &ldvl_ilp64, VR, &ldvr_ilp64, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -529,20 +563,22 @@ pub unsafe extern "C" fn dgeqrf_(
     let provider = get_dgeqrf_for_lp64();
     match provider {
         DgeqrfProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(m_lp64, n_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&m_lp64, &n_lp64, A, &lda_lp64, tau, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         DgeqrfProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(m_ilp64, n_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, tau, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -563,18 +599,18 @@ pub unsafe extern "C" fn dgesc2_(
     let provider = get_dgesc2_for_lp64();
     match provider {
         Dgesc2Provider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *const i32 = ipiv as *const i32;
-            let jpiv_lp64: *const i32 = jpiv as *const i32;
-            fun(n_lp64, A, lda_lp64, rhs, ipiv_lp64, jpiv_lp64, scale)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ipiv_lp64: i32 = *ipiv as i32;
+            let jpiv_lp64: i32 = *jpiv as i32;
+            fun(&n_lp64, A, &lda_lp64, rhs, &ipiv_lp64, &jpiv_lp64, scale)
         }
         Dgesc2Provider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *const i64 = ipiv as *const i64;
-            let jpiv_ilp64: *const i64 = jpiv as *const i64;
-            fun(n_ilp64, A, lda_ilp64, rhs, ipiv_ilp64, jpiv_ilp64, scale)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ipiv_ilp64: i64 = *ipiv as i64;
+            let jpiv_ilp64: i64 = *jpiv as i64;
+            fun(&n_ilp64, A, &lda_ilp64, rhs, &ipiv_ilp64, &jpiv_ilp64, scale)
         }
     }
 }
@@ -596,22 +632,26 @@ pub unsafe extern "C" fn dgesv_(
     let provider = get_dgesv_for_lp64();
     match provider {
         DgesvProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let nrhs_lp64: *const i32 = nrhs as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *mut i32 = ipiv as *mut i32;
-            let ldb_lp64: *const i32 = ldb as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(n_lp64, nrhs_lp64, A, lda_lp64, ipiv_lp64, B, ldb_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let nrhs_lp64: i32 = *nrhs as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut ipiv_lp64: i32 = *ipiv as i32;
+            let ldb_lp64: i32 = *ldb as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&n_lp64, &nrhs_lp64, A, &lda_lp64, &mut ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
+            *ipiv = ipiv_lp64 as lapackint;
+            *info = info_lp64 as lapackint;
         }
         DgesvProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let nrhs_ilp64: *const i64 = nrhs as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *mut i64 = ipiv as *mut i64;
-            let ldb_ilp64: *const i64 = ldb as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(n_ilp64, nrhs_ilp64, A, lda_ilp64, ipiv_ilp64, B, ldb_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let nrhs_ilp64: i64 = *nrhs as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            let ldb_ilp64: i64 = *ldb as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            *ipiv = ipiv_ilp64 as lapackint;
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -639,24 +679,26 @@ pub unsafe extern "C" fn dgesvd_(
     let provider = get_dgesvd_for_lp64();
     match provider {
         DgesvdProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ldu_lp64: *const i32 = ldu as *const i32;
-            let ldvt_lp64: *const i32 = ldvt as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(jobu, jobvt, m_lp64, n_lp64, A, lda_lp64, S, U, ldu_lp64, VT, ldvt_lp64, work, lwork_lp64, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ldu_lp64: i32 = *ldu as i32;
+            let ldvt_lp64: i32 = *ldvt as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(jobu, jobvt, &m_lp64, &n_lp64, A, &lda_lp64, S, U, &ldu_lp64, VT, &ldvt_lp64, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         DgesvdProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ldu_ilp64: *const i64 = ldu as *const i64;
-            let ldvt_ilp64: *const i64 = ldvt as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(jobu, jobvt, m_ilp64, n_ilp64, A, lda_ilp64, S, U, ldu_ilp64, VT, ldvt_ilp64, work, lwork_ilp64, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ldu_ilp64: i64 = *ldu as i64;
+            let ldvt_ilp64: i64 = *ldvt as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(jobu, jobvt, &m_ilp64, &n_ilp64, A, &lda_ilp64, S, U, &ldu_ilp64, VT, &ldvt_ilp64, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -676,20 +718,26 @@ pub unsafe extern "C" fn dgetc2_(
     let provider = get_dgetc2_for_lp64();
     match provider {
         Dgetc2Provider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *mut i32 = ipiv as *mut i32;
-            let jpiv_lp64: *mut i32 = jpiv as *mut i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(n_lp64, A, lda_lp64, ipiv_lp64, jpiv_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut ipiv_lp64: i32 = *ipiv as i32;
+            let mut jpiv_lp64: i32 = *jpiv as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut jpiv_lp64, &mut info_lp64);
+            *ipiv = ipiv_lp64 as lapackint;
+            *jpiv = jpiv_lp64 as lapackint;
+            *info = info_lp64 as lapackint;
         }
         Dgetc2Provider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *mut i64 = ipiv as *mut i64;
-            let jpiv_ilp64: *mut i64 = jpiv as *mut i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(n_ilp64, A, lda_ilp64, ipiv_ilp64, jpiv_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            let mut jpiv_ilp64: i64 = *jpiv as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut jpiv_ilp64, &mut info_ilp64);
+            *ipiv = ipiv_ilp64 as lapackint;
+            *jpiv = jpiv_ilp64 as lapackint;
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -709,20 +757,24 @@ pub unsafe extern "C" fn dgetrf_(
     let provider = get_dgetrf_for_lp64();
     match provider {
         DgetrfProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *mut i32 = ipiv as *mut i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(m_lp64, n_lp64, A, lda_lp64, ipiv_lp64, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut ipiv_lp64: i32 = *ipiv as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&m_lp64, &n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut info_lp64);
+            *ipiv = ipiv_lp64 as lapackint;
+            *info = info_lp64 as lapackint;
         }
         DgetrfProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *mut i64 = ipiv as *mut i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(m_ilp64, n_ilp64, A, lda_ilp64, ipiv_ilp64, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut info_ilp64);
+            *ipiv = ipiv_ilp64 as lapackint;
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -743,20 +795,22 @@ pub unsafe extern "C" fn dgetri_(
     let provider = get_dgetri_for_lp64();
     match provider {
         DgetriProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *const i32 = ipiv as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(n_lp64, A, lda_lp64, ipiv_lp64, work, lwork_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ipiv_lp64: i32 = *ipiv as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&n_lp64, A, &lda_lp64, &ipiv_lp64, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         DgetriProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *const i64 = ipiv as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(n_ilp64, A, lda_ilp64, ipiv_ilp64, work, lwork_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ipiv_ilp64: i64 = *ipiv as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&n_ilp64, A, &lda_ilp64, &ipiv_ilp64, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -779,22 +833,24 @@ pub unsafe extern "C" fn dgetrs_(
     let provider = get_dgetrs_for_lp64();
     match provider {
         DgetrsProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let nrhs_lp64: *const i32 = nrhs as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *const i32 = ipiv as *const i32;
-            let ldb_lp64: *const i32 = ldb as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(trans, n_lp64, nrhs_lp64, A, lda_lp64, ipiv_lp64, B, ldb_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let nrhs_lp64: i32 = *nrhs as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ipiv_lp64: i32 = *ipiv as i32;
+            let ldb_lp64: i32 = *ldb as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(trans, &n_lp64, &nrhs_lp64, A, &lda_lp64, &ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         DgetrsProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let nrhs_ilp64: *const i64 = nrhs as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *const i64 = ipiv as *const i64;
-            let ldb_ilp64: *const i64 = ldb as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(trans, n_ilp64, nrhs_ilp64, A, lda_ilp64, ipiv_ilp64, B, ldb_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let nrhs_ilp64: i64 = *nrhs as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ipiv_ilp64: i64 = *ipiv as i64;
+            let ldb_ilp64: i64 = *ldb as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(trans, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -817,22 +873,24 @@ pub unsafe extern "C" fn dorgqr_(
     let provider = get_dorgqr_for_lp64();
     match provider {
         DorgqrProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let k_lp64: *const i32 = k as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(m_lp64, n_lp64, k_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let k_lp64: i32 = *k as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&m_lp64, &n_lp64, &k_lp64, A, &lda_lp64, tau, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         DorgqrProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let k_ilp64: *const i64 = k as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(m_ilp64, n_ilp64, k_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let k_ilp64: i64 = *k as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&m_ilp64, &n_ilp64, &k_ilp64, A, &lda_ilp64, tau, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -851,16 +909,18 @@ pub unsafe extern "C" fn dpotrf_(
     let provider = get_dpotrf_for_lp64();
     match provider {
         DpotrfProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(uplo, n_lp64, A, lda_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(uplo, &n_lp64, A, &lda_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         DpotrfProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(uplo, n_ilp64, A, lda_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(uplo, &n_ilp64, A, &lda_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -883,18 +943,20 @@ pub unsafe extern "C" fn dsyev_(
     let provider = get_dsyev_for_lp64();
     match provider {
         DsyevProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(jobz, uplo, n_lp64, A, lda_lp64, W, work, lwork_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(jobz, uplo, &n_lp64, A, &lda_lp64, W, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         DsyevProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(jobz, uplo, n_ilp64, A, lda_ilp64, W, work, lwork_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(jobz, uplo, &n_ilp64, A, &lda_ilp64, W, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -918,20 +980,22 @@ pub unsafe extern "C" fn dtrtrs_(
     let provider = get_dtrtrs_for_lp64();
     match provider {
         DtrtrsProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let nrhs_lp64: *const i32 = nrhs as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ldb_lp64: *const i32 = ldb as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(uplo, trans, diag, n_lp64, nrhs_lp64, A, lda_lp64, B, ldb_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let nrhs_lp64: i32 = *nrhs as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ldb_lp64: i32 = *ldb as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(uplo, trans, diag, &n_lp64, &nrhs_lp64, A, &lda_lp64, B, &ldb_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         DtrtrsProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let nrhs_ilp64: *const i64 = nrhs as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ldb_ilp64: *const i64 = ldb as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(uplo, trans, diag, n_ilp64, nrhs_ilp64, A, lda_ilp64, B, ldb_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let nrhs_ilp64: i64 = *nrhs as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ldb_ilp64: i64 = *ldb as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(uplo, trans, diag, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -959,22 +1023,24 @@ pub unsafe extern "C" fn sgeev_(
     let provider = get_sgeev_for_lp64();
     match provider {
         SgeevProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ldvl_lp64: *const i32 = ldvl as *const i32;
-            let ldvr_lp64: *const i32 = ldvr as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(jobvl, jobvr, n_lp64, A, lda_lp64, WR, WI, VL, ldvl_lp64, VR, ldvr_lp64, work, lwork_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ldvl_lp64: i32 = *ldvl as i32;
+            let ldvr_lp64: i32 = *ldvr as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(jobvl, jobvr, &n_lp64, A, &lda_lp64, WR, WI, VL, &ldvl_lp64, VR, &ldvr_lp64, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         SgeevProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ldvl_ilp64: *const i64 = ldvl as *const i64;
-            let ldvr_ilp64: *const i64 = ldvr as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(jobvl, jobvr, n_ilp64, A, lda_ilp64, WR, WI, VL, ldvl_ilp64, VR, ldvr_ilp64, work, lwork_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ldvl_ilp64: i64 = *ldvl as i64;
+            let ldvr_ilp64: i64 = *ldvr as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(jobvl, jobvr, &n_ilp64, A, &lda_ilp64, WR, WI, VL, &ldvl_ilp64, VR, &ldvr_ilp64, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -996,20 +1062,22 @@ pub unsafe extern "C" fn sgeqrf_(
     let provider = get_sgeqrf_for_lp64();
     match provider {
         SgeqrfProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(m_lp64, n_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&m_lp64, &n_lp64, A, &lda_lp64, tau, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         SgeqrfProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(m_ilp64, n_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, tau, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1030,18 +1098,18 @@ pub unsafe extern "C" fn sgesc2_(
     let provider = get_sgesc2_for_lp64();
     match provider {
         Sgesc2Provider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *const i32 = ipiv as *const i32;
-            let jpiv_lp64: *const i32 = jpiv as *const i32;
-            fun(n_lp64, A, lda_lp64, rhs, ipiv_lp64, jpiv_lp64, scale)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ipiv_lp64: i32 = *ipiv as i32;
+            let jpiv_lp64: i32 = *jpiv as i32;
+            fun(&n_lp64, A, &lda_lp64, rhs, &ipiv_lp64, &jpiv_lp64, scale)
         }
         Sgesc2Provider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *const i64 = ipiv as *const i64;
-            let jpiv_ilp64: *const i64 = jpiv as *const i64;
-            fun(n_ilp64, A, lda_ilp64, rhs, ipiv_ilp64, jpiv_ilp64, scale)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ipiv_ilp64: i64 = *ipiv as i64;
+            let jpiv_ilp64: i64 = *jpiv as i64;
+            fun(&n_ilp64, A, &lda_ilp64, rhs, &ipiv_ilp64, &jpiv_ilp64, scale)
         }
     }
 }
@@ -1063,22 +1131,26 @@ pub unsafe extern "C" fn sgesv_(
     let provider = get_sgesv_for_lp64();
     match provider {
         SgesvProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let nrhs_lp64: *const i32 = nrhs as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *mut i32 = ipiv as *mut i32;
-            let ldb_lp64: *const i32 = ldb as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(n_lp64, nrhs_lp64, A, lda_lp64, ipiv_lp64, B, ldb_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let nrhs_lp64: i32 = *nrhs as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut ipiv_lp64: i32 = *ipiv as i32;
+            let ldb_lp64: i32 = *ldb as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&n_lp64, &nrhs_lp64, A, &lda_lp64, &mut ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
+            *ipiv = ipiv_lp64 as lapackint;
+            *info = info_lp64 as lapackint;
         }
         SgesvProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let nrhs_ilp64: *const i64 = nrhs as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *mut i64 = ipiv as *mut i64;
-            let ldb_ilp64: *const i64 = ldb as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(n_ilp64, nrhs_ilp64, A, lda_ilp64, ipiv_ilp64, B, ldb_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let nrhs_ilp64: i64 = *nrhs as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            let ldb_ilp64: i64 = *ldb as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            *ipiv = ipiv_ilp64 as lapackint;
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1106,24 +1178,26 @@ pub unsafe extern "C" fn sgesvd_(
     let provider = get_sgesvd_for_lp64();
     match provider {
         SgesvdProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ldu_lp64: *const i32 = ldu as *const i32;
-            let ldvt_lp64: *const i32 = ldvt as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(jobu, jobvt, m_lp64, n_lp64, A, lda_lp64, S, U, ldu_lp64, VT, ldvt_lp64, work, lwork_lp64, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ldu_lp64: i32 = *ldu as i32;
+            let ldvt_lp64: i32 = *ldvt as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(jobu, jobvt, &m_lp64, &n_lp64, A, &lda_lp64, S, U, &ldu_lp64, VT, &ldvt_lp64, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         SgesvdProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ldu_ilp64: *const i64 = ldu as *const i64;
-            let ldvt_ilp64: *const i64 = ldvt as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(jobu, jobvt, m_ilp64, n_ilp64, A, lda_ilp64, S, U, ldu_ilp64, VT, ldvt_ilp64, work, lwork_ilp64, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ldu_ilp64: i64 = *ldu as i64;
+            let ldvt_ilp64: i64 = *ldvt as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(jobu, jobvt, &m_ilp64, &n_ilp64, A, &lda_ilp64, S, U, &ldu_ilp64, VT, &ldvt_ilp64, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1143,20 +1217,26 @@ pub unsafe extern "C" fn sgetc2_(
     let provider = get_sgetc2_for_lp64();
     match provider {
         Sgetc2Provider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *mut i32 = ipiv as *mut i32;
-            let jpiv_lp64: *mut i32 = jpiv as *mut i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(n_lp64, A, lda_lp64, ipiv_lp64, jpiv_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut ipiv_lp64: i32 = *ipiv as i32;
+            let mut jpiv_lp64: i32 = *jpiv as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut jpiv_lp64, &mut info_lp64);
+            *ipiv = ipiv_lp64 as lapackint;
+            *jpiv = jpiv_lp64 as lapackint;
+            *info = info_lp64 as lapackint;
         }
         Sgetc2Provider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *mut i64 = ipiv as *mut i64;
-            let jpiv_ilp64: *mut i64 = jpiv as *mut i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(n_ilp64, A, lda_ilp64, ipiv_ilp64, jpiv_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            let mut jpiv_ilp64: i64 = *jpiv as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut jpiv_ilp64, &mut info_ilp64);
+            *ipiv = ipiv_ilp64 as lapackint;
+            *jpiv = jpiv_ilp64 as lapackint;
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1176,20 +1256,24 @@ pub unsafe extern "C" fn sgetrf_(
     let provider = get_sgetrf_for_lp64();
     match provider {
         SgetrfProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *mut i32 = ipiv as *mut i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(m_lp64, n_lp64, A, lda_lp64, ipiv_lp64, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut ipiv_lp64: i32 = *ipiv as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&m_lp64, &n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut info_lp64);
+            *ipiv = ipiv_lp64 as lapackint;
+            *info = info_lp64 as lapackint;
         }
         SgetrfProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *mut i64 = ipiv as *mut i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(m_ilp64, n_ilp64, A, lda_ilp64, ipiv_ilp64, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut info_ilp64);
+            *ipiv = ipiv_ilp64 as lapackint;
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1210,20 +1294,22 @@ pub unsafe extern "C" fn sgetri_(
     let provider = get_sgetri_for_lp64();
     match provider {
         SgetriProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *const i32 = ipiv as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(n_lp64, A, lda_lp64, ipiv_lp64, work, lwork_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ipiv_lp64: i32 = *ipiv as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&n_lp64, A, &lda_lp64, &ipiv_lp64, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         SgetriProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *const i64 = ipiv as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(n_ilp64, A, lda_ilp64, ipiv_ilp64, work, lwork_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ipiv_ilp64: i64 = *ipiv as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&n_ilp64, A, &lda_ilp64, &ipiv_ilp64, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1246,22 +1332,24 @@ pub unsafe extern "C" fn sgetrs_(
     let provider = get_sgetrs_for_lp64();
     match provider {
         SgetrsProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let nrhs_lp64: *const i32 = nrhs as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *const i32 = ipiv as *const i32;
-            let ldb_lp64: *const i32 = ldb as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(trans, n_lp64, nrhs_lp64, A, lda_lp64, ipiv_lp64, B, ldb_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let nrhs_lp64: i32 = *nrhs as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ipiv_lp64: i32 = *ipiv as i32;
+            let ldb_lp64: i32 = *ldb as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(trans, &n_lp64, &nrhs_lp64, A, &lda_lp64, &ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         SgetrsProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let nrhs_ilp64: *const i64 = nrhs as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *const i64 = ipiv as *const i64;
-            let ldb_ilp64: *const i64 = ldb as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(trans, n_ilp64, nrhs_ilp64, A, lda_ilp64, ipiv_ilp64, B, ldb_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let nrhs_ilp64: i64 = *nrhs as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ipiv_ilp64: i64 = *ipiv as i64;
+            let ldb_ilp64: i64 = *ldb as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(trans, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1284,22 +1372,24 @@ pub unsafe extern "C" fn sorgqr_(
     let provider = get_sorgqr_for_lp64();
     match provider {
         SorgqrProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let k_lp64: *const i32 = k as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(m_lp64, n_lp64, k_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let k_lp64: i32 = *k as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&m_lp64, &n_lp64, &k_lp64, A, &lda_lp64, tau, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         SorgqrProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let k_ilp64: *const i64 = k as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(m_ilp64, n_ilp64, k_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let k_ilp64: i64 = *k as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&m_ilp64, &n_ilp64, &k_ilp64, A, &lda_ilp64, tau, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1318,16 +1408,18 @@ pub unsafe extern "C" fn spotrf_(
     let provider = get_spotrf_for_lp64();
     match provider {
         SpotrfProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(uplo, n_lp64, A, lda_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(uplo, &n_lp64, A, &lda_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         SpotrfProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(uplo, n_ilp64, A, lda_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(uplo, &n_ilp64, A, &lda_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1350,18 +1442,20 @@ pub unsafe extern "C" fn ssyev_(
     let provider = get_ssyev_for_lp64();
     match provider {
         SsyevProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(jobz, uplo, n_lp64, A, lda_lp64, W, work, lwork_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(jobz, uplo, &n_lp64, A, &lda_lp64, W, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         SsyevProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(jobz, uplo, n_ilp64, A, lda_ilp64, W, work, lwork_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(jobz, uplo, &n_ilp64, A, &lda_ilp64, W, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1385,20 +1479,22 @@ pub unsafe extern "C" fn strtrs_(
     let provider = get_strtrs_for_lp64();
     match provider {
         StrtrsProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let nrhs_lp64: *const i32 = nrhs as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ldb_lp64: *const i32 = ldb as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(uplo, trans, diag, n_lp64, nrhs_lp64, A, lda_lp64, B, ldb_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let nrhs_lp64: i32 = *nrhs as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ldb_lp64: i32 = *ldb as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(uplo, trans, diag, &n_lp64, &nrhs_lp64, A, &lda_lp64, B, &ldb_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         StrtrsProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let nrhs_ilp64: *const i64 = nrhs as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ldb_ilp64: *const i64 = ldb as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(uplo, trans, diag, n_ilp64, nrhs_ilp64, A, lda_ilp64, B, ldb_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let nrhs_ilp64: i64 = *nrhs as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ldb_ilp64: i64 = *ldb as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(uplo, trans, diag, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1426,22 +1522,24 @@ pub unsafe extern "C" fn zgeev_(
     let provider = get_zgeev_for_lp64();
     match provider {
         ZgeevProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ldvl_lp64: *const i32 = ldvl as *const i32;
-            let ldvr_lp64: *const i32 = ldvr as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(jobvl, jobvr, n_lp64, A, lda_lp64, W, VL, ldvl_lp64, VR, ldvr_lp64, work, lwork_lp64, rwork, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ldvl_lp64: i32 = *ldvl as i32;
+            let ldvr_lp64: i32 = *ldvr as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(jobvl, jobvr, &n_lp64, A, &lda_lp64, W, VL, &ldvl_lp64, VR, &ldvr_lp64, work, &lwork_lp64, rwork, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         ZgeevProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ldvl_ilp64: *const i64 = ldvl as *const i64;
-            let ldvr_ilp64: *const i64 = ldvr as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(jobvl, jobvr, n_ilp64, A, lda_ilp64, W, VL, ldvl_ilp64, VR, ldvr_ilp64, work, lwork_ilp64, rwork, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ldvl_ilp64: i64 = *ldvl as i64;
+            let ldvr_ilp64: i64 = *ldvr as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(jobvl, jobvr, &n_ilp64, A, &lda_ilp64, W, VL, &ldvl_ilp64, VR, &ldvr_ilp64, work, &lwork_ilp64, rwork, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1463,20 +1561,22 @@ pub unsafe extern "C" fn zgeqrf_(
     let provider = get_zgeqrf_for_lp64();
     match provider {
         ZgeqrfProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(m_lp64, n_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&m_lp64, &n_lp64, A, &lda_lp64, tau, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         ZgeqrfProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(m_ilp64, n_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, tau, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1497,18 +1597,18 @@ pub unsafe extern "C" fn zgesc2_(
     let provider = get_zgesc2_for_lp64();
     match provider {
         Zgesc2Provider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *const i32 = ipiv as *const i32;
-            let jpiv_lp64: *const i32 = jpiv as *const i32;
-            fun(n_lp64, A, lda_lp64, rhs, ipiv_lp64, jpiv_lp64, scale)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ipiv_lp64: i32 = *ipiv as i32;
+            let jpiv_lp64: i32 = *jpiv as i32;
+            fun(&n_lp64, A, &lda_lp64, rhs, &ipiv_lp64, &jpiv_lp64, scale)
         }
         Zgesc2Provider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *const i64 = ipiv as *const i64;
-            let jpiv_ilp64: *const i64 = jpiv as *const i64;
-            fun(n_ilp64, A, lda_ilp64, rhs, ipiv_ilp64, jpiv_ilp64, scale)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ipiv_ilp64: i64 = *ipiv as i64;
+            let jpiv_ilp64: i64 = *jpiv as i64;
+            fun(&n_ilp64, A, &lda_ilp64, rhs, &ipiv_ilp64, &jpiv_ilp64, scale)
         }
     }
 }
@@ -1530,22 +1630,26 @@ pub unsafe extern "C" fn zgesv_(
     let provider = get_zgesv_for_lp64();
     match provider {
         ZgesvProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let nrhs_lp64: *const i32 = nrhs as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *mut i32 = ipiv as *mut i32;
-            let ldb_lp64: *const i32 = ldb as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(n_lp64, nrhs_lp64, A, lda_lp64, ipiv_lp64, B, ldb_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let nrhs_lp64: i32 = *nrhs as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut ipiv_lp64: i32 = *ipiv as i32;
+            let ldb_lp64: i32 = *ldb as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&n_lp64, &nrhs_lp64, A, &lda_lp64, &mut ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
+            *ipiv = ipiv_lp64 as lapackint;
+            *info = info_lp64 as lapackint;
         }
         ZgesvProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let nrhs_ilp64: *const i64 = nrhs as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *mut i64 = ipiv as *mut i64;
-            let ldb_ilp64: *const i64 = ldb as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(n_ilp64, nrhs_ilp64, A, lda_ilp64, ipiv_ilp64, B, ldb_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let nrhs_ilp64: i64 = *nrhs as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            let ldb_ilp64: i64 = *ldb as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            *ipiv = ipiv_ilp64 as lapackint;
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1574,24 +1678,26 @@ pub unsafe extern "C" fn zgesvd_(
     let provider = get_zgesvd_for_lp64();
     match provider {
         ZgesvdProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ldu_lp64: *const i32 = ldu as *const i32;
-            let ldvt_lp64: *const i32 = ldvt as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(jobu, jobvt, m_lp64, n_lp64, A, lda_lp64, S, U, ldu_lp64, VT, ldvt_lp64, work, lwork_lp64, rwork, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ldu_lp64: i32 = *ldu as i32;
+            let ldvt_lp64: i32 = *ldvt as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(jobu, jobvt, &m_lp64, &n_lp64, A, &lda_lp64, S, U, &ldu_lp64, VT, &ldvt_lp64, work, &lwork_lp64, rwork, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         ZgesvdProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ldu_ilp64: *const i64 = ldu as *const i64;
-            let ldvt_ilp64: *const i64 = ldvt as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(jobu, jobvt, m_ilp64, n_ilp64, A, lda_ilp64, S, U, ldu_ilp64, VT, ldvt_ilp64, work, lwork_ilp64, rwork, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ldu_ilp64: i64 = *ldu as i64;
+            let ldvt_ilp64: i64 = *ldvt as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(jobu, jobvt, &m_ilp64, &n_ilp64, A, &lda_ilp64, S, U, &ldu_ilp64, VT, &ldvt_ilp64, work, &lwork_ilp64, rwork, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1611,20 +1717,26 @@ pub unsafe extern "C" fn zgetc2_(
     let provider = get_zgetc2_for_lp64();
     match provider {
         Zgetc2Provider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *mut i32 = ipiv as *mut i32;
-            let jpiv_lp64: *mut i32 = jpiv as *mut i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(n_lp64, A, lda_lp64, ipiv_lp64, jpiv_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut ipiv_lp64: i32 = *ipiv as i32;
+            let mut jpiv_lp64: i32 = *jpiv as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut jpiv_lp64, &mut info_lp64);
+            *ipiv = ipiv_lp64 as lapackint;
+            *jpiv = jpiv_lp64 as lapackint;
+            *info = info_lp64 as lapackint;
         }
         Zgetc2Provider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *mut i64 = ipiv as *mut i64;
-            let jpiv_ilp64: *mut i64 = jpiv as *mut i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(n_ilp64, A, lda_ilp64, ipiv_ilp64, jpiv_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            let mut jpiv_ilp64: i64 = *jpiv as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut jpiv_ilp64, &mut info_ilp64);
+            *ipiv = ipiv_ilp64 as lapackint;
+            *jpiv = jpiv_ilp64 as lapackint;
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1644,20 +1756,24 @@ pub unsafe extern "C" fn zgetrf_(
     let provider = get_zgetrf_for_lp64();
     match provider {
         ZgetrfProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *mut i32 = ipiv as *mut i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(m_lp64, n_lp64, A, lda_lp64, ipiv_lp64, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut ipiv_lp64: i32 = *ipiv as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&m_lp64, &n_lp64, A, &lda_lp64, &mut ipiv_lp64, &mut info_lp64);
+            *ipiv = ipiv_lp64 as lapackint;
+            *info = info_lp64 as lapackint;
         }
         ZgetrfProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *mut i64 = ipiv as *mut i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(m_ilp64, n_ilp64, A, lda_ilp64, ipiv_ilp64, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut ipiv_ilp64: i64 = *ipiv as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&m_ilp64, &n_ilp64, A, &lda_ilp64, &mut ipiv_ilp64, &mut info_ilp64);
+            *ipiv = ipiv_ilp64 as lapackint;
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1678,20 +1794,22 @@ pub unsafe extern "C" fn zgetri_(
     let provider = get_zgetri_for_lp64();
     match provider {
         ZgetriProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *const i32 = ipiv as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(n_lp64, A, lda_lp64, ipiv_lp64, work, lwork_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ipiv_lp64: i32 = *ipiv as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&n_lp64, A, &lda_lp64, &ipiv_lp64, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         ZgetriProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *const i64 = ipiv as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(n_ilp64, A, lda_ilp64, ipiv_ilp64, work, lwork_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ipiv_ilp64: i64 = *ipiv as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&n_ilp64, A, &lda_ilp64, &ipiv_ilp64, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1714,22 +1832,24 @@ pub unsafe extern "C" fn zgetrs_(
     let provider = get_zgetrs_for_lp64();
     match provider {
         ZgetrsProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let nrhs_lp64: *const i32 = nrhs as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ipiv_lp64: *const i32 = ipiv as *const i32;
-            let ldb_lp64: *const i32 = ldb as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(trans, n_lp64, nrhs_lp64, A, lda_lp64, ipiv_lp64, B, ldb_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let nrhs_lp64: i32 = *nrhs as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ipiv_lp64: i32 = *ipiv as i32;
+            let ldb_lp64: i32 = *ldb as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(trans, &n_lp64, &nrhs_lp64, A, &lda_lp64, &ipiv_lp64, B, &ldb_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         ZgetrsProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let nrhs_ilp64: *const i64 = nrhs as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ipiv_ilp64: *const i64 = ipiv as *const i64;
-            let ldb_ilp64: *const i64 = ldb as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(trans, n_ilp64, nrhs_ilp64, A, lda_ilp64, ipiv_ilp64, B, ldb_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let nrhs_ilp64: i64 = *nrhs as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ipiv_ilp64: i64 = *ipiv as i64;
+            let ldb_ilp64: i64 = *ldb as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(trans, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, &ipiv_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1753,18 +1873,20 @@ pub unsafe extern "C" fn zheev_(
     let provider = get_zheev_for_lp64();
     match provider {
         ZheevProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(jobz, uplo, n_lp64, A, lda_lp64, W, work, lwork_lp64, rwork, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(jobz, uplo, &n_lp64, A, &lda_lp64, W, work, &lwork_lp64, rwork, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         ZheevProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(jobz, uplo, n_ilp64, A, lda_ilp64, W, work, lwork_ilp64, rwork, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(jobz, uplo, &n_ilp64, A, &lda_ilp64, W, work, &lwork_ilp64, rwork, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1783,16 +1905,18 @@ pub unsafe extern "C" fn zpotrf_(
     let provider = get_zpotrf_for_lp64();
     match provider {
         ZpotrfProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(uplo, n_lp64, A, lda_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(uplo, &n_lp64, A, &lda_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         ZpotrfProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(uplo, n_ilp64, A, lda_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(uplo, &n_ilp64, A, &lda_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1816,20 +1940,22 @@ pub unsafe extern "C" fn ztrtrs_(
     let provider = get_ztrtrs_for_lp64();
     match provider {
         ZtrtrsProvider::Lp64(fun) => {
-            let n_lp64: *const i32 = n as *const i32;
-            let nrhs_lp64: *const i32 = nrhs as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let ldb_lp64: *const i32 = ldb as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(uplo, trans, diag, n_lp64, nrhs_lp64, A, lda_lp64, B, ldb_lp64, info_lp64)
+            let n_lp64: i32 = *n as i32;
+            let nrhs_lp64: i32 = *nrhs as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let ldb_lp64: i32 = *ldb as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(uplo, trans, diag, &n_lp64, &nrhs_lp64, A, &lda_lp64, B, &ldb_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         ZtrtrsProvider::Ilp64(fun) => {
-            let n_ilp64: *const i64 = n as *const i64;
-            let nrhs_ilp64: *const i64 = nrhs as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let ldb_ilp64: *const i64 = ldb as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(uplo, trans, diag, n_ilp64, nrhs_ilp64, A, lda_ilp64, B, ldb_ilp64, info_ilp64)
+            let n_ilp64: i64 = *n as i64;
+            let nrhs_ilp64: i64 = *nrhs as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let ldb_ilp64: i64 = *ldb as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(uplo, trans, diag, &n_ilp64, &nrhs_ilp64, A, &lda_ilp64, B, &ldb_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }
@@ -1852,22 +1978,24 @@ pub unsafe extern "C" fn zungqr_(
     let provider = get_zungqr_for_lp64();
     match provider {
         ZungqrProvider::Lp64(fun) => {
-            let m_lp64: *const i32 = m as *const i32;
-            let n_lp64: *const i32 = n as *const i32;
-            let k_lp64: *const i32 = k as *const i32;
-            let lda_lp64: *const i32 = lda as *const i32;
-            let lwork_lp64: *const i32 = lwork as *const i32;
-            let info_lp64: *mut i32 = info as *mut i32;
-            fun(m_lp64, n_lp64, k_lp64, A, lda_lp64, tau, work, lwork_lp64, info_lp64)
+            let m_lp64: i32 = *m as i32;
+            let n_lp64: i32 = *n as i32;
+            let k_lp64: i32 = *k as i32;
+            let lda_lp64: i32 = *lda as i32;
+            let lwork_lp64: i32 = *lwork as i32;
+            let mut info_lp64: i32 = *info as i32;
+            fun(&m_lp64, &n_lp64, &k_lp64, A, &lda_lp64, tau, work, &lwork_lp64, &mut info_lp64);
+            *info = info_lp64 as lapackint;
         }
         ZungqrProvider::Ilp64(fun) => {
-            let m_ilp64: *const i64 = m as *const i64;
-            let n_ilp64: *const i64 = n as *const i64;
-            let k_ilp64: *const i64 = k as *const i64;
-            let lda_ilp64: *const i64 = lda as *const i64;
-            let lwork_ilp64: *const i64 = lwork as *const i64;
-            let info_ilp64: *mut i64 = info as *mut i64;
-            fun(m_ilp64, n_ilp64, k_ilp64, A, lda_ilp64, tau, work, lwork_ilp64, info_ilp64)
+            let m_ilp64: i64 = *m as i64;
+            let n_ilp64: i64 = *n as i64;
+            let k_ilp64: i64 = *k as i64;
+            let lda_ilp64: i64 = *lda as i64;
+            let lwork_ilp64: i64 = *lwork as i64;
+            let mut info_ilp64: i64 = *info as i64;
+            fun(&m_ilp64, &n_ilp64, &k_ilp64, A, &lda_ilp64, tau, work, &lwork_ilp64, &mut info_ilp64);
+            *info = info_ilp64 as lapackint;
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,20 @@
 //!
 //! ## Supported Functions
 //!
-//! The current generated surface supports `xGESV`, `xGETRF`, `xGETRS`,
-//! `xGETRI`, `xPOTRF`, `xGESVD`, `sSYEV`, `dSYEV`, `xGETC2`, and `xGESC2`.
+//! The generated Fortran surface supports:
+//!
+//! - `xGESV`, `xGETRF`, `xGETRS`, `xGETRI`, `xPOTRF`
+//! - `xGESVD`
+//! - `xGEQRF`, real `xORGQR`, complex `xUNGQR`
+//! - `xTRTRS`
+//! - `s/dSYEV`, `c/zHEEV`
+//! - `xGEEV`
+//! - supplemental complete-pivoting LU routines `xGETC2` and `xGESC2`
+//!
+//! The default build keeps the consumer-facing Fortran symbols LP64-compatible.
+//! Register ILP64 host providers with the `_ilp64` registration functions; do not
+//! enable the `ilp64` feature just because the host provider is ILP64. The feature
+//! changes the consumer ABI too.
 
 mod backend;
 pub mod fortran;

--- a/tests/dual_width_tenferro_surface.rs
+++ b/tests/dual_width_tenferro_surface.rs
@@ -1,0 +1,266 @@
+extern crate lapack_inject;
+
+use core::ptr::{read_unaligned, write_unaligned};
+use lapack_inject::*;
+use num_complex::Complex64;
+use std::ffi::c_char;
+
+#[cfg(not(feature = "ilp64"))]
+unsafe extern "C" fn fake_dgeqrf_ilp64(
+    m: *const i64,
+    n: *const i64,
+    _a: *mut f64,
+    lda: *const i64,
+    tau: *mut f64,
+    work: *mut f64,
+    lwork: *const i64,
+    info: *mut i64,
+) {
+    assert_eq!(read_unaligned(m), 3);
+    assert_eq!(read_unaligned(n), 2);
+    assert_eq!(read_unaligned(lda), 3);
+    assert_eq!(read_unaligned(lwork), -1);
+    *work = 128.0;
+    *tau = 1.0;
+    write_unaligned(info, 0);
+}
+
+#[cfg(not(feature = "ilp64"))]
+#[test]
+fn lp64_dgeqrf_symbol_dispatches_to_ilp64_provider() {
+    unsafe {
+        assert!(matches!(register_dgeqrf_ilp64(fake_dgeqrf_ilp64), 0 | 2));
+    }
+    let m = 3_i32;
+    let n = 2_i32;
+    let mut a = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+    let lda = 3_i32;
+    let mut tau = [0.0_f64];
+    let lwork = -1_i32;
+    let mut work = [0.0_f64];
+    let mut info = -1_i32;
+    unsafe {
+        lapack_sys::dgeqrf_(
+            &m, &n, a.as_mut_ptr(), &lda, tau.as_mut_ptr(),
+            work.as_mut_ptr(), &lwork, &mut info,
+        );
+    }
+    assert_eq!(info, 0);
+    assert_eq!(work[0], 128.0);
+}
+
+#[cfg(not(feature = "ilp64"))]
+unsafe extern "C" fn fake_dorgqr_ilp64(
+    m: *const i64,
+    n: *const i64,
+    k: *const i64,
+    _a: *mut f64,
+    lda: *const i64,
+    tau: *const f64,
+    work: *mut f64,
+    lwork: *const i64,
+    info: *mut i64,
+) {
+    assert_eq!(read_unaligned(m), 3);
+    assert_eq!(read_unaligned(n), 2);
+    assert_eq!(read_unaligned(k), 1);
+    assert_eq!(read_unaligned(lda), 3);
+    assert_eq!(read_unaligned(lwork), -1);
+    assert_eq!(*tau, 0.5);
+    *work = 64.0;
+    write_unaligned(info, 0);
+}
+
+#[cfg(not(feature = "ilp64"))]
+#[test]
+fn lp64_dorgqr_symbol_dispatches_to_ilp64_provider() {
+    unsafe {
+        assert!(matches!(register_dorgqr_ilp64(fake_dorgqr_ilp64), 0 | 2));
+    }
+    let m = 3_i32;
+    let n = 2_i32;
+    let k = 1_i32;
+    let mut a = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+    let lda = 3_i32;
+    let tau = [0.5_f64];
+    let lwork = -1_i32;
+    let mut work = [0.0_f64];
+    let mut info = -1_i32;
+    unsafe {
+        lapack_sys::dorgqr_(
+            &m, &n, &k, a.as_mut_ptr(), &lda, tau.as_ptr(),
+            work.as_mut_ptr(), &lwork, &mut info,
+        );
+    }
+    assert_eq!(info, 0);
+    assert_eq!(work[0], 64.0);
+}
+
+#[cfg(not(feature = "ilp64"))]
+unsafe extern "C" fn fake_dtrtrs_ilp64(
+    uplo: *const c_char,
+    trans: *const c_char,
+    diag: *const c_char,
+    n: *const i64,
+    nrhs: *const i64,
+    _a: *const f64,
+    lda: *const i64,
+    b: *mut f64,
+    ldb: *const i64,
+    info: *mut i64,
+) {
+    assert_eq!(*uplo as u8, b'U');
+    assert_eq!(*trans as u8, b'N');
+    assert_eq!(*diag as u8, b'N');
+    assert_eq!(read_unaligned(n), 2);
+    assert_eq!(read_unaligned(nrhs), 1);
+    assert_eq!(read_unaligned(lda), 2);
+    assert_eq!(read_unaligned(ldb), 2);
+    std::slice::from_raw_parts_mut(b, 2).copy_from_slice(&[11.0, 13.0]);
+    write_unaligned(info, 0);
+}
+
+#[cfg(not(feature = "ilp64"))]
+#[test]
+fn lp64_dtrtrs_symbol_dispatches_to_ilp64_provider() {
+    unsafe {
+        assert!(matches!(register_dtrtrs_ilp64(fake_dtrtrs_ilp64), 0 | 2));
+    }
+    let uplo = b'U' as c_char;
+    let trans = b'N' as c_char;
+    let diag = b'N' as c_char;
+    let n = 2_i32;
+    let nrhs = 1_i32;
+    let a = [1.0, 0.0, 0.0, 1.0];
+    let lda = 2_i32;
+    let mut b = [1.0, 2.0];
+    let ldb = 2_i32;
+    let mut info = -1_i32;
+    unsafe {
+        lapack_sys::dtrtrs_(
+            &uplo, &trans, &diag, &n, &nrhs, a.as_ptr(), &lda,
+            b.as_mut_ptr(), &ldb, &mut info,
+        );
+    }
+    assert_eq!(info, 0);
+    assert_eq!(b, [11.0, 13.0]);
+}
+
+#[cfg(not(feature = "ilp64"))]
+unsafe extern "C" fn fake_zheev_ilp64(
+    jobz: *const c_char,
+    uplo: *const c_char,
+    n: *const i64,
+    _a: *mut Complex64,
+    lda: *const i64,
+    w: *mut f64,
+    work: *mut Complex64,
+    lwork: *const i64,
+    rwork: *mut f64,
+    info: *mut i64,
+) {
+    assert_eq!(*jobz as u8, b'N');
+    assert_eq!(*uplo as u8, b'U');
+    assert_eq!(read_unaligned(n), 2);
+    assert_eq!(read_unaligned(lda), 2);
+    assert_eq!(read_unaligned(lwork), -1);
+    *w = 3.0;
+    *work = Complex64::new(64.0, 0.0);
+    *rwork = 1.0;
+    write_unaligned(info, 0);
+}
+
+#[cfg(not(feature = "ilp64"))]
+#[test]
+fn lp64_zheev_symbol_dispatches_to_ilp64_provider() {
+    use lapack_sys::lapack_complex_double;
+    unsafe {
+        assert!(matches!(register_zheev_ilp64(fake_zheev_ilp64), 0 | 2));
+    }
+    let jobz = b'N' as c_char;
+    let uplo = b'U' as c_char;
+    let n = 2_i32;
+    let mut a = [
+        Complex64::new(1.0, 0.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(2.0, 0.0),
+    ];
+    let lda = 2_i32;
+    let mut w = [0.0_f64; 2];
+    let lwork = -1_i32;
+    let mut work = [Complex64::new(0.0, 0.0)];
+    let mut rwork = [0.0_f64];
+    let mut info = -1_i32;
+    unsafe {
+        lapack_sys::zheev_(
+            &jobz, &uplo, &n, a.as_mut_ptr() as *mut lapack_complex_double,
+            &lda, w.as_mut_ptr(),
+            work.as_mut_ptr() as *mut lapack_complex_double,
+            &lwork, rwork.as_mut_ptr(), &mut info,
+        );
+    }
+    assert_eq!(info, 0);
+    assert_eq!(w[0], 3.0);
+}
+
+#[cfg(not(feature = "ilp64"))]
+unsafe extern "C" fn fake_dgeev_ilp64(
+    jobvl: *const c_char,
+    jobvr: *const c_char,
+    n: *const i64,
+    _a: *mut f64,
+    lda: *const i64,
+    wr: *mut f64,
+    wi: *mut f64,
+    vl: *mut f64,
+    ldvl: *const i64,
+    vr: *mut f64,
+    ldvr: *const i64,
+    work: *mut f64,
+    lwork: *const i64,
+    info: *mut i64,
+) {
+    assert_eq!(*jobvl as u8, b'N');
+    assert_eq!(*jobvr as u8, b'N');
+    assert_eq!(read_unaligned(n), 2);
+    assert_eq!(read_unaligned(lda), 2);
+    assert_eq!(read_unaligned(lwork), -1);
+    *wr = 4.0;
+    *wi = 0.0;
+    *work = 128.0;
+    write_unaligned(info, 0);
+}
+
+#[cfg(not(feature = "ilp64"))]
+#[test]
+fn lp64_dgeev_symbol_dispatches_to_ilp64_provider() {
+    unsafe {
+        assert!(matches!(register_dgeev_ilp64(fake_dgeev_ilp64), 0 | 2));
+    }
+    let jobvl = b'N' as c_char;
+    let jobvr = b'N' as c_char;
+    let n = 2_i32;
+    let mut a = [1.0, 2.0, 3.0, 4.0];
+    let lda = 2_i32;
+    let mut wr = [0.0_f64; 2];
+    let mut wi = [0.0_f64; 2];
+    let mut vl = [0.0_f64; 1];
+    let ldvl = 1_i32;
+    let mut vr = [0.0_f64; 1];
+    let ldvr = 1_i32;
+    let lwork = -1_i32;
+    let mut work = [0.0_f64];
+    let mut info = -1_i32;
+    unsafe {
+        lapack_sys::dgeev_(
+            &jobvl, &jobvr, &n, a.as_mut_ptr(), &lda,
+            wr.as_mut_ptr(), wi.as_mut_ptr(),
+            vl.as_mut_ptr(), &ldvl,
+            vr.as_mut_ptr(), &ldvr,
+            work.as_mut_ptr(), &lwork, &mut info,
+        );
+    }
+    assert_eq!(info, 0);
+    assert_eq!(wr[0], 4.0);
+}

--- a/tests/dual_width_tenferro_surface.rs
+++ b/tests/dual_width_tenferro_surface.rs
@@ -304,3 +304,159 @@ fn lp64_dgeev_symbol_dispatches_to_ilp64_provider() {
     assert_eq!(info, 0);
     assert_eq!(wr[0], 4.0);
 }
+
+#[cfg(not(feature = "ilp64"))]
+unsafe extern "C" fn fake_dgetrf_ilp64(
+    m: *const i64,
+    n: *const i64,
+    _a: *mut f64,
+    lda: *const i64,
+    ipiv: *mut i64,
+    info: *mut i64,
+) {
+    assert_eq!(read_unaligned(m), 3);
+    assert_eq!(read_unaligned(n), 3);
+    assert_eq!(read_unaligned(lda), 3);
+    // Write pivot array [1, 3, 2]
+    *ipiv.add(0) = 1i64;
+    *ipiv.add(1) = 3i64;
+    *ipiv.add(2) = 2i64;
+    write_unaligned(info, 0);
+}
+
+#[cfg(not(feature = "ilp64"))]
+#[test]
+fn lp64_dgetrf_symbol_bridges_ipiv_array_to_ilp64_provider() {
+    unsafe {
+        assert!(matches!(register_dgetrf_ilp64(fake_dgetrf_ilp64), 0 | 2));
+    }
+    let m = 3_i32;
+    let n = 3_i32;
+    let mut a = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+    let lda = 3_i32;
+    let mut ipiv = [0_i32; 3];
+    let mut info = -1_i32;
+    unsafe {
+        lapack_sys::dgetrf_(&m, &n, a.as_mut_ptr(), &lda, ipiv.as_mut_ptr(), &mut info);
+    }
+    assert_eq!(info, 0);
+    assert_eq!(ipiv, [1, 3, 2], "all pivot elements should be bridged back");
+}
+
+#[cfg(not(feature = "ilp64"))]
+unsafe extern "C" fn fake_dgetc2_ilp64(
+    n: *const i64,
+    _a: *mut f64,
+    lda: *const i64,
+    ipiv: *mut i64,
+    jpiv: *mut i64,
+    info: *mut i64,
+) {
+    assert_eq!(read_unaligned(n), 3);
+    assert_eq!(read_unaligned(lda), 3);
+    *ipiv.add(0) = 3i64;
+    *ipiv.add(1) = 1i64;
+    *ipiv.add(2) = 2i64;
+    *jpiv.add(0) = 2i64;
+    *jpiv.add(1) = 3i64;
+    *jpiv.add(2) = 1i64;
+    write_unaligned(info, 0);
+}
+
+#[cfg(not(feature = "ilp64"))]
+#[test]
+fn lp64_dgetc2_symbol_bridges_ipiv_jpiv_arrays_to_ilp64_provider() {
+    extern "C" {
+        fn dgetc2_(
+            n: *const lapackint,
+            a: *mut f64,
+            lda: *const lapackint,
+            ipiv: *mut lapackint,
+            jpiv: *mut lapackint,
+            info: *mut lapackint,
+        );
+    }
+    unsafe {
+        assert!(matches!(register_dgetc2_ilp64(fake_dgetc2_ilp64), 0 | 2));
+    }
+    let n: lapackint = 3;
+    let lda: lapackint = 3;
+    let mut a = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+    let mut ipiv: [lapackint; 3] = [0; 3];
+    let mut jpiv: [lapackint; 3] = [0; 3];
+    let mut info: lapackint = -1;
+    unsafe {
+        dgetc2_(
+            &n,
+            a.as_mut_ptr(),
+            &lda,
+            ipiv.as_mut_ptr(),
+            jpiv.as_mut_ptr(),
+            &mut info,
+        );
+    }
+    assert_eq!(info, 0);
+    assert_eq!(ipiv, [3, 1, 2], "all ipiv elements bridged back");
+    assert_eq!(jpiv, [2, 3, 1], "all jpiv elements bridged back");
+}
+
+#[cfg(not(feature = "ilp64"))]
+unsafe extern "C" fn fake_dgesc2_ilp64(
+    n: *const i64,
+    a: *const f64,
+    lda: *const i64,
+    rhs: *mut f64,
+    ipiv: *const i64,
+    jpiv: *const i64,
+    scale: *mut f64,
+) {
+    assert_eq!(read_unaligned(n), 3);
+    assert_eq!(read_unaligned(lda), 3);
+    assert_eq!(*ipiv.add(0), 3i64, "ipiv[0] bridged");
+    assert_eq!(*ipiv.add(1), 1i64, "ipiv[1] bridged");
+    assert_eq!(*ipiv.add(2), 2i64, "ipiv[2] bridged");
+    assert_eq!(*jpiv.add(0), 2i64, "jpiv[0] bridged");
+    assert_eq!(*jpiv.add(1), 3i64, "jpiv[1] bridged");
+    assert_eq!(*jpiv.add(2), 1i64, "jpiv[2] bridged");
+    *rhs = *a;
+    *scale = 1.0;
+}
+
+#[cfg(not(feature = "ilp64"))]
+#[test]
+fn lp64_dgesc2_symbol_bridges_ipiv_jpiv_arrays_to_ilp64_provider() {
+    extern "C" {
+        fn dgesc2_(
+            n: *const lapackint,
+            a: *const f64,
+            lda: *const lapackint,
+            rhs: *mut f64,
+            ipiv: *const lapackint,
+            jpiv: *const lapackint,
+            scale: *mut f64,
+        );
+    }
+    unsafe {
+        assert!(matches!(register_dgesc2_ilp64(fake_dgesc2_ilp64), 0 | 2));
+    }
+    let n: lapackint = 3;
+    let lda: lapackint = 3;
+    let a = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+    let mut rhs = [0.0_f64];
+    let ipiv: [lapackint; 3] = [3, 1, 2];
+    let jpiv: [lapackint; 3] = [2, 3, 1];
+    let mut scale = 0.0_f64;
+    unsafe {
+        dgesc2_(
+            &n,
+            a.as_ptr(),
+            &lda,
+            rhs.as_mut_ptr(),
+            ipiv.as_ptr(),
+            jpiv.as_ptr(),
+            &mut scale,
+        );
+    }
+    assert_eq!(rhs[0], 1.0);
+    assert_eq!(scale, 1.0);
+}

--- a/tests/dual_width_tenferro_surface.rs
+++ b/tests/dual_width_tenferro_surface.rs
@@ -1,8 +1,12 @@
 extern crate lapack_inject;
 
+#[cfg(not(feature = "ilp64"))]
 use core::ptr::{read_unaligned, write_unaligned};
+#[cfg(not(feature = "ilp64"))]
 use lapack_inject::*;
+#[cfg(not(feature = "ilp64"))]
 use num_complex::Complex64;
+#[cfg(not(feature = "ilp64"))]
 use std::ffi::c_char;
 
 #[cfg(not(feature = "ilp64"))]
@@ -41,8 +45,14 @@ fn lp64_dgeqrf_symbol_dispatches_to_ilp64_provider() {
     let mut info = -1_i32;
     unsafe {
         lapack_sys::dgeqrf_(
-            &m, &n, a.as_mut_ptr(), &lda, tau.as_mut_ptr(),
-            work.as_mut_ptr(), &lwork, &mut info,
+            &m,
+            &n,
+            a.as_mut_ptr(),
+            &lda,
+            tau.as_mut_ptr(),
+            work.as_mut_ptr(),
+            &lwork,
+            &mut info,
         );
     }
     assert_eq!(info, 0);
@@ -88,8 +98,15 @@ fn lp64_dorgqr_symbol_dispatches_to_ilp64_provider() {
     let mut info = -1_i32;
     unsafe {
         lapack_sys::dorgqr_(
-            &m, &n, &k, a.as_mut_ptr(), &lda, tau.as_ptr(),
-            work.as_mut_ptr(), &lwork, &mut info,
+            &m,
+            &n,
+            &k,
+            a.as_mut_ptr(),
+            &lda,
+            tau.as_ptr(),
+            work.as_mut_ptr(),
+            &lwork,
+            &mut info,
         );
     }
     assert_eq!(info, 0);
@@ -138,8 +155,16 @@ fn lp64_dtrtrs_symbol_dispatches_to_ilp64_provider() {
     let mut info = -1_i32;
     unsafe {
         lapack_sys::dtrtrs_(
-            &uplo, &trans, &diag, &n, &nrhs, a.as_ptr(), &lda,
-            b.as_mut_ptr(), &ldb, &mut info,
+            &uplo,
+            &trans,
+            &diag,
+            &n,
+            &nrhs,
+            a.as_ptr(),
+            &lda,
+            b.as_mut_ptr(),
+            &ldb,
+            &mut info,
         );
     }
     assert_eq!(info, 0);
@@ -194,10 +219,16 @@ fn lp64_zheev_symbol_dispatches_to_ilp64_provider() {
     let mut info = -1_i32;
     unsafe {
         lapack_sys::zheev_(
-            &jobz, &uplo, &n, a.as_mut_ptr() as *mut lapack_complex_double,
-            &lda, w.as_mut_ptr(),
+            &jobz,
+            &uplo,
+            &n,
+            a.as_mut_ptr() as *mut lapack_complex_double,
+            &lda,
+            w.as_mut_ptr(),
             work.as_mut_ptr() as *mut lapack_complex_double,
-            &lwork, rwork.as_mut_ptr(), &mut info,
+            &lwork,
+            rwork.as_mut_ptr(),
+            &mut info,
         );
     }
     assert_eq!(info, 0);
@@ -213,10 +244,10 @@ unsafe extern "C" fn fake_dgeev_ilp64(
     lda: *const i64,
     wr: *mut f64,
     wi: *mut f64,
-    vl: *mut f64,
-    ldvl: *const i64,
-    vr: *mut f64,
-    ldvr: *const i64,
+    _vl: *mut f64,
+    _ldvl: *const i64,
+    _vr: *mut f64,
+    _ldvr: *const i64,
     work: *mut f64,
     lwork: *const i64,
     info: *mut i64,
@@ -254,11 +285,20 @@ fn lp64_dgeev_symbol_dispatches_to_ilp64_provider() {
     let mut info = -1_i32;
     unsafe {
         lapack_sys::dgeev_(
-            &jobvl, &jobvr, &n, a.as_mut_ptr(), &lda,
-            wr.as_mut_ptr(), wi.as_mut_ptr(),
-            vl.as_mut_ptr(), &ldvl,
-            vr.as_mut_ptr(), &ldvr,
-            work.as_mut_ptr(), &lwork, &mut info,
+            &jobvl,
+            &jobvr,
+            &n,
+            a.as_mut_ptr(),
+            &lda,
+            wr.as_mut_ptr(),
+            wi.as_mut_ptr(),
+            vl.as_mut_ptr(),
+            &ldvl,
+            vr.as_mut_ptr(),
+            &ldvr,
+            work.as_mut_ptr(),
+            &lwork,
+            &mut info,
         );
     }
     assert_eq!(info, 0);

--- a/tests/lapack_sys_compat.rs
+++ b/tests/lapack_sys_compat.rs
@@ -8,6 +8,24 @@ extern crate lapack_inject;
 
 // Now lapack-sys functions should resolve to lapack-inject's exports
 use lapack_sys;
+use libloading::Library;
+
+fn load_built_lapack_inject() -> Library {
+    let profile = if cfg!(debug_assertions) { "debug" } else { "release" };
+    let lib_name = if cfg!(target_os = "macos") {
+        "liblapack_inject.dylib"
+    } else if cfg!(target_os = "windows") {
+        "lapack_inject.dll"
+    } else {
+        "liblapack_inject.so"
+    };
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join(profile)
+        .join(lib_name);
+    unsafe { Library::new(&path) }
+        .unwrap_or_else(|err| panic!("failed to load {}: {err}", path.display()))
+}
 
 /// Test that we can take the address of lapack-sys functions
 /// (they resolve to lapack-inject's symbols)
@@ -79,4 +97,36 @@ fn symbols_are_linkable() {
     let _ = lapack_sys::zgels_ as *const ();
 
     println!("All tested symbols are linkable!");
+}
+
+#[test]
+fn tenferro_lapack_symbols_are_exported_by_cdylib() {
+    let lib = load_built_lapack_inject();
+    for symbol in [
+        b"dgesvd_\0".as_slice(),
+        b"zgesvd_\0".as_slice(),
+        b"dgeqrf_\0".as_slice(),
+        b"zgeqrf_\0".as_slice(),
+        b"dorgqr_\0".as_slice(),
+        b"zungqr_\0".as_slice(),
+        b"dtrtrs_\0".as_slice(),
+        b"ztrtrs_\0".as_slice(),
+        b"dpotrf_\0".as_slice(),
+        b"zpotrf_\0".as_slice(),
+        b"dgetrf_\0".as_slice(),
+        b"zgetrf_\0".as_slice(),
+        b"dsyev_\0".as_slice(),
+        b"zheev_\0".as_slice(),
+        b"dgeev_\0".as_slice(),
+        b"zgeev_\0".as_slice(),
+        b"dgetc2_\0".as_slice(),
+        b"dgesc2_\0".as_slice(),
+        b"zgetc2_\0".as_slice(),
+        b"zgesc2_\0".as_slice(),
+    ] {
+        unsafe {
+            lib.get::<*const ()>(symbol)
+                .unwrap_or_else(|err| panic!("missing {}: {err}", String::from_utf8_lossy(symbol)));
+        }
+    }
 }

--- a/tests/lapack_sys_compat.rs
+++ b/tests/lapack_sys_compat.rs
@@ -11,7 +11,11 @@ use lapack_sys;
 use libloading::Library;
 
 fn load_built_lapack_inject() -> Library {
-    let profile = if cfg!(debug_assertions) { "debug" } else { "release" };
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
     let lib_name = if cfg!(target_os = "macos") {
         "liblapack_inject.dylib"
     } else if cfg!(target_os = "windows") {


### PR DESCRIPTION
## Summary

- extend generated Fortran LAPACK exports to cover the tenferro CPU BLAS linalg surface (`xGEQRF`, `xORGQR`/`xUNGQR`, `xTRTRS`, `xGEEV`, `c/zHEEV`)
- fix cross-width LP64/ILP64 dispatch so scalar integer params are widened/narrowed by value, not pointer-cast
- add metadata-driven array bridging for LAPACK integer arrays such as `ipiv`/`jpiv`
- add regression tests for exported symbols and LP64 consumer -> ILP64 provider dispatch, including multi-element pivot arrays
- make `scripts/check_symbols.py` repo-relative and generated-surface aware

Fixes #5.

## Validation

- `cargo fmt --all --check`
- `cargo test`
- `cargo test --features ilp64`
- `cargo build`
- `python3 scripts/check_symbols.py --lapack-sys-path "$HOME/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lapack-sys-0.15.0/src/lapack.rs" --library target/debug/liblapack_inject.so`
- `nm -g target/debug/liblapack_inject.so | rg " T (dgesvd_|zgesvd_|dgeqrf_|zgeqrf_|dorgqr_|zungqr_|dtrtrs_|ztrtrs_|dpotrf_|zpotrf_|dgetrf_|zgetrf_|dsyev_|zheev_|dgeev_|zgeev_|dgetc2_|dgesc2_|zgetc2_|zgesc2_)$"`

Generated with Codex; implementation delegated to opencode per maintainer request.
